### PR TITLE
Map features into previously stored settings

### DIFF
--- a/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
@@ -239,10 +239,9 @@ private class FeatureSet[T](private val features: Array[Feature[T, _, _, _]])
     val settingLookup = s.map{setting => (setting.name, setting)}.toMap
     features.map { feature =>
       val name = feature.transformer.name
-      settingLookup
-        .get(feature.transformer.name)
-        .map(setting => feature.transformer.decodeAggregator(setting.aggregators))
-        .getOrElse(sys.error(s"Attempting to load existing settings but it does not contain $name"))
+      lazy val msg = s"Attempting to load existing settings but it does not contain $name"
+      require(settingLookup.contains(name), msg)
+      feature.transformer.decodeAggregator(settingLookup(feature.transformer.name).aggregators)
     }
   }
 }

--- a/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
@@ -18,7 +18,6 @@
 package com.spotify.featran
 
 import com.spotify.featran.transformers.{Settings, Transformer}
-
 import scala.language.{higherKinds, implicitConversions}
 
 /**
@@ -237,14 +236,13 @@ private class FeatureSet[T](private val features: Array[Feature[T, _, _, _]])
   }
 
   def decodeAggregators(s: Seq[Settings]): ARRAY = {
-    val r = new Array[Option[Any]](n)
-    var i = 0
-    val it = s.iterator
-    while (i < n) {
-      r(i) = features(i).transformer.decodeAggregator(it.next().aggregators)
-      i += 1
+    val settingLookup = s.map{setting => (setting.name, setting)}.toMap
+    features.map { feature =>
+      val name = feature.transformer.name
+      settingLookup
+        .get(feature.transformer.name)
+        .map(setting => feature.transformer.decodeAggregator(setting.aggregators))
+        .getOrElse(sys.error(s"Attempting to load existing settings but it does not contain $name"))
     }
-    r
   }
-
 }

--- a/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
@@ -31,6 +31,7 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
   }
 
   private val id = Identity("id")
+  private val id2 = Identity("id2")
 
   property("required") = Prop.forAll { xs: List[Record] =>
     val f = FeatureSpec.of[Record].required(_.d)(id).extract(xs)
@@ -77,6 +78,16 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
     Prop.all(
       f.featureNames == Seq(Seq("id")),
       f.featureValuesWithOriginal[Seq[Double]] == xs.map(r => (Seq(r.d), r)))
+  }
+
+  property("extra stored feature") = Prop.forAll { xs: List[Record] =>
+    val spec1 = FeatureSpec.of[Record].required(_.d)(id).required(_.d)(id2)
+    val spec2 = FeatureSpec.of[Record].required(_.d)(id)
+    val f2 = spec2.extractWithSettings(xs,  spec1.extract(xs).featureSettings)
+
+    Prop.all(
+      f2.featureNames == Seq(Seq("id")),
+      f2.featureValuesWithOriginal[Seq[Double]] == xs.map(r => (Seq(r.d), r)))
   }
 
   property("names") = Prop.forAll(Gen.alphaStr) { s =>

--- a/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
@@ -90,6 +90,21 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
       f2.featureValuesWithOriginal[Seq[Double]] == xs.map(r => (Seq(r.d), r)))
   }
 
+  property("missing feature in settings") = Prop.forAll { xs: List[Record] =>
+    val spec1 = FeatureSpec.of[Record].required(_.d)(id)
+    val spec2 = FeatureSpec.of[Record].required(_.d)(id).required(_.d)(id2)
+    val settings = spec1.extract(xs).featureSettings
+
+    val t = Try(spec2.extractWithSettings(xs,  settings).featureValues[Seq[Double]])
+    val msg = "requirement failed: Attempting to load existing settings but it does not contain id2"
+
+    Prop.all(
+      t.isFailure,
+      t.failed.get.isInstanceOf[IllegalArgumentException],
+      t.failed.get.getMessage == msg
+    )
+  }
+
   property("names") = Prop.forAll(Gen.alphaStr) { s =>
     val msg = if (s == null || s.isEmpty) {
       "requirement failed: name cannot be null or empty"


### PR DESCRIPTION
At times features will need to be extracted with more fields in the case of labels etc.  This review makes it so you can reuse those aggregations generated previously where the new features to be extracted is a subset of the original features.  If the new features is not a strict subset an error is thrown.