### PR TITLE
Make non serializable error explicit instead of "silent" NPE

### DIFF
--- a/core/src/main/scala/com/spotify/featran/FeatureExtractor.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureExtractor.scala
@@ -38,7 +38,10 @@ class FeatureExtractor[M[_]: CollectionType, T] private[featran]
   @transient private val dt: CollectionType[M] = implicitly[CollectionType[M]]
   import dt.Ops._
 
-  @transient private lazy val as: M[(T, ARRAY)] = input.map(o => (o, fs.unsafeGet(o)))
+  @transient private lazy val as: M[(T, ARRAY)] = {
+    val g = fs // defeat closure
+    input.map(o => (o, g.unsafeGet(o)))
+  }
   @transient private lazy val aggregate: M[ARRAY] = settings match {
     case Some(x) => x.map { s =>
       import io.circe.generic.auto._

--- a/scio/src/test/scala/com/spotify/featran/scio/ScioTest.scala
+++ b/scio/src/test/scala/com/spotify/featran/scio/ScioTest.scala
@@ -47,4 +47,22 @@ class ScioTest extends PipelineSpec {
     }
   }
 
+  private class NonSerializable {
+    def method(a: String): Double = a.toDouble
+  }
+
+  // scalastyle:off no.whitespace.before.left.bracket
+  it should "fail on throw serializable feature" in {
+    runWithContext { sc =>
+      val foo = new NonSerializable()
+      val f = FeatureSpec.of[(String, Int)]
+        .required(e => foo.method(e._1))(Identity("foo"))
+        .extract(sc.parallelize(data))
+
+      val thrown = the [RuntimeException] thrownBy f.featureValues[Seq[Double]]
+      thrown.getMessage should startWith("unable to serialize anonymous function")
+    }
+  }
+  // scalastyle:on no.whitespace.before.left.bracket
+
 }


### PR DESCRIPTION
If fs is not serializable it would be null out by CC, which would
result in NPE, instead make sure that fs is not null out, and fail
earlier and with serialization exception.