### PR TITLE
VectorIdentity and NHotWeightedEncoder Transformers

### DIFF
--- a/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
@@ -1,0 +1,52 @@
+package com.spotify.featran.transformers
+
+import java.net.{URLDecoder, URLEncoder}
+
+import com.spotify.featran.FeatureBuilder
+import com.twitter.algebird.Aggregator
+
+/**
+ * Class for a weighted vector.  Also can be thought as
+ * a named sparse vector
+ * @param name Name of the field
+ * @param value Weight on the field
+ */
+case class WeightedValues(name: String, value: Double)
+
+object NHotWeightedEncoder {
+  /**
+   * Create a NHotWeightedEncoder with a given name
+   *
+   * This transformer finds all unique names and maps them to
+   * the vector with the weighted value instead of 1.0 as is the
+   * case with the normal [[NHotEncoder]].
+   *
+   * @param name Name of the feature
+   * @return Transformer
+   */
+  def apply(name: String): Transformer[Seq[WeightedValues], Set[String], Array[String]] =
+    new NHotWeightedEncoder(name)
+}
+
+private class NHotWeightedEncoder(name: String)
+  extends Transformer[Seq[WeightedValues], Set[String], Array[String]](name) {
+
+  override val aggregator: Aggregator[Seq[WeightedValues], Set[String], Array[String]] =
+    Aggregators.from[Seq[WeightedValues]](_.map(_.name).toSet).to(_.toArray.sorted)
+
+  override def featureDimension(c: Array[String]): Int = c.length
+
+  override def featureNames(c: Array[String]): Seq[String] = c.map(name + "_" + _).toSeq
+
+  override def buildFeatures(a: Option[Seq[WeightedValues]], c: Array[String],
+                             fb: FeatureBuilder[_]): Unit = {
+    val as = a.map(_.map(n => (n.name, n.value)).toMap).getOrElse(Map.empty)
+    c.foreach(s => if (as.contains(s)) fb.add(name + "_" + s, as(s)) else fb.skip())
+  }
+
+  override def encodeAggregator(c: Option[Array[String]]): Option[String] =
+    c.map(_.map(URLEncoder.encode(_, "UTF-8")).mkString(","))
+
+  override def decodeAggregator(s: Option[String]): Option[Array[String]] =
+    s.map(_.split(",").map(URLDecoder.decode(_, "UTF-8")))
+}

--- a/core/src/main/scala/com/spotify/featran/transformers/VectorIdentity.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/VectorIdentity.scala
@@ -1,0 +1,32 @@
+package com.spotify.featran.transformers
+
+import com.spotify.featran.FeatureBuilder
+import com.twitter.algebird.Aggregator
+
+object VectorIdentity {
+  /**
+   * Takes a vector with a fixed length and maps it to the features.
+   *
+   * Similiar to Identity but for a Sequence of Doubles
+   */
+  def apply(name: String, length: Int): Transformer[Seq[Double], Unit, Unit] =
+    new VectorIdentity(name, length)
+}
+
+private class VectorIdentity(name: String, length: Int)
+  extends Transformer[Seq[Double], Unit, Unit](name) {
+
+  private val names = 0.until(length).map(name + "_" + _)
+
+  override val aggregator: Aggregator[Seq[Double], Unit, Unit] = Aggregators.unit
+
+  override def featureDimension(c: Unit): Int = length
+
+  override def featureNames(c: Unit): Seq[String] = names
+
+  override def buildFeatures(a: Option[Seq[Double]], c: Unit, fb: FeatureBuilder[_]): Unit =
+    if(a.isDefined) fb.add(names.toIterator, a.get.toArray) else fb.skip(length)
+
+  override def encodeAggregator(c: Option[Unit]): Option[String] = c.map(_ => "")
+  override def decodeAggregator(s: Option[String]): Option[Unit] = s.map(_ => ())
+}

--- a/core/src/main/scala/com/spotify/featran/transformers/VectorIdentity.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/VectorIdentity.scala
@@ -29,4 +29,5 @@ private class VectorIdentity(name: String, length: Int)
 
   override def encodeAggregator(c: Option[Unit]): Option[String] = c.map(_ => "")
   override def decodeAggregator(s: Option[String]): Option[Unit] = s.map(_ => ())
+  override def params: Map[String, String] = Map("length" -> length.toString)
 }

--- a/core/src/test/scala/com/spotify/featran/examples/Example.scala
+++ b/core/src/test/scala/com/spotify/featran/examples/Example.scala
@@ -82,7 +82,7 @@ object Example {
       .required(toArray)(Normalizer("norm2", 3.0))
       .required(_.s2)(NHotEncoder("n_hot"))
       //Same as above but when the names have weights
-      .required(_.s2.map(s => WeightedValues(s, 0.5)))(NHotWeightedEncoder("n_hot_weighted"))
+      .required(_.s2.map(s => WeightedValue(s, 0.5)))(NHotWeightedEncoder("n_hot_weighted"))
       // Record to Array[Double] composite feature
       // Polynomial expansion with default degree 2
       .required(toArray)(PolynomialExpansion("poly1"))

--- a/core/src/test/scala/com/spotify/featran/examples/Example.scala
+++ b/core/src/test/scala/com/spotify/featran/examples/Example.scala
@@ -58,6 +58,8 @@ object Example {
       .required(_.b.asDouble)(Identity("id1"))
       // Requird field with Float to Double conversion
       .required(_.f.toDouble)(Identity("id2"))
+      // Vector Identity
+      .required(v => Seq(v.f.toDouble))(VectorIdentity("vec_identity", 1))
       // Binarize with default threshold 0.0
       .required(_.d1)(Binarizer("bin1"))
       // Binarize with custom threshold
@@ -79,6 +81,8 @@ object Example {
       // Normalize vector with custom p
       .required(toArray)(Normalizer("norm2", 3.0))
       .required(_.s2)(NHotEncoder("n_hot"))
+      //Same as above but when the names have weights
+      .required(_.s2.map(s => WeightedValues(s, 0.5)))(NHotWeightedEncoder("n_hot_weighted"))
       // Record to Array[Double] composite feature
       // Polynomial expansion with default degree 2
       .required(toArray)(PolynomialExpansion("poly1"))

--- a/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
@@ -6,7 +6,7 @@ class NHotWeightedEncoderSpec extends TransformerProp("NHotWeightedEncoder") {
   private implicit val weightedVector = Arbitrary {
     val weightedValueGen = for {
       value <- Gen.chooseNum(-1.0, 1.0)
-      n <- Arbitrary.arbString.arbitrary.suchThat(!_.isEmpty)
+      n <- Arbitrary.arbString.arbitrary
     } yield WeightedValue(n, value)
 
     Gen.choose(1, 5).flatMap(Gen.listOfN(_, weightedValueGen))

--- a/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
@@ -3,17 +3,21 @@ package com.spotify.featran.transformers
 import org.scalacheck.{Arbitrary, Gen, Prop}
 
 class NHotWeightedEncoderSpec extends TransformerProp("NHotWeightedEncoder") {
-  private implicit val labelArb = Arbitrary {
-    Gen.choose(1, 10).flatMap(Gen.listOfN(_, Gen.alphaStr))
+  private implicit val weightedVector = Arbitrary {
+    val weightedValueGen = for {
+      value <- Gen.chooseNum(-1.0, 1.0)
+      n <- Arbitrary.arbString.arbitrary.suchThat(!_.isEmpty)
+    } yield WeightedValue(n, value)
+
+    Gen.choose(1, 5).flatMap(Gen.listOfN(_, weightedValueGen))
   }
 
-  property("default") = Prop.forAll { xs: List[List[String]] =>
-    val vecs = xs.map(_.map(n => WeightedValues(n, 0.5)))
-    val cats = xs.flatten.distinct.sorted
+  property("default") = Prop.forAll { xs: List[List[WeightedValue]] =>
+    val cats = xs.flatten.map(_.name).distinct.sorted
     val names = cats.map("n_hot_" + _)
-    val expected = xs.map(s => cats.map(c => if (s.contains(c)) 0.5 else 0.0))
+    val expected = xs.map(s => cats.map(c => s.find(_.name == c).map(_.value).getOrElse(0.0)))
     val missing = cats.map(_ => 0.0)
-    val oob = List((List(WeightedValues("s1", 0.2), WeightedValues("s2", 0.1)), missing))
-    test[Seq[WeightedValues]](NHotWeightedEncoder("n_hot"), vecs, names, expected, missing, oob)
+    val oob = List((List(WeightedValue("s1", 0.2), WeightedValue("s2", 0.1)), missing))
+    test[Seq[WeightedValue]](NHotWeightedEncoder("n_hot"), xs, names, expected, missing, oob)
   }
 }

--- a/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
@@ -1,0 +1,19 @@
+package com.spotify.featran.transformers
+
+import org.scalacheck.{Arbitrary, Gen, Prop}
+
+class NHotWeightedEncoderSpec extends TransformerProp("NHotWeightedEncoder") {
+  private implicit val labelArb = Arbitrary {
+    Gen.choose(1, 10).flatMap(Gen.listOfN(_, Gen.alphaStr))
+  }
+
+  property("default") = Prop.forAll { xs: List[List[String]] =>
+    val vecs = xs.map(_.map(n => WeightedValues(n, 0.5)))
+    val cats = xs.flatten.distinct.sorted
+    val names = cats.map("n_hot_" + _)
+    val expected = xs.map(s => cats.map(c => if (s.contains(c)) 0.5 else 0.0))
+    val missing = cats.map(_ => 0.0)
+    val oob = List((List(WeightedValues("s1", 0.2), WeightedValues("s2", 0.1)), missing))
+    test[Seq[WeightedValues]](NHotWeightedEncoder("n_hot"), vecs, names, expected, missing, oob)
+  }
+}

--- a/core/src/test/scala/com/spotify/featran/transformers/VectorIdentitySpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/VectorIdentitySpec.scala
@@ -1,0 +1,10 @@
+package com.spotify.featran.transformers
+
+import org.scalacheck.Prop
+
+class VectorIdentitySpec extends TransformerProp("VectorIdentity") {
+  property("default") = Prop.forAll { xs: List[Double] =>
+    val vecs = xs.map(a => Seq(a))
+    test[Seq[Double]](VectorIdentity("id", 1), vecs, Seq("id_0"), xs.map(Seq(_)), Seq(0.0))
+  }
+}


### PR DESCRIPTION
The Vector Identity Transformer makes it easy to take a dense vector and push it through into the features.  NHotWeightedEncoder is similar to NHotEncoder but where each field has a weight.  For example when you have some probability that a label belongs on an item. 