### PR TITLE
add von mises transformer

### DIFF
--- a/core/src/main/scala/com/spotify/featran/transformers/VonMisesEvaluator.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/VonMisesEvaluator.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.featran.transformers
+
+import breeze.stats.distributions.VonMises
+import com.spotify.featran.FeatureBuilder
+import com.twitter.algebird.Aggregator
+
+
+object VonMisesEvaluator {
+  /**
+    * Transform a column of continuous features that represent the mean of a von Mises distribution
+    * to n columns of continuous features. The number n represent the number of points to
+    * evaluate the von Mises distribution. The von Mises pdf is given by
+    *
+    * f(x | mu, kappa, scale) = exp(kappa * cos(scale*(x-mu)) / (2*pi*Io(kappa))
+    *
+    * and is only valid for x, mu in the interval [0, 2*pi/scale].
+    */
+  def apply(name: String, kappa: Double, scale: Double, points: Array[Double]):
+  Transformer[Double, Unit, Unit] =
+    new VonMisesEvaluator(name, kappa, scale, points)
+
+  def getProbability(x: Double, mu: Double, kappa: Double, scale: Double): Double = {
+    val muScaled = mu * scale
+    val vm = VonMises(muScaled, kappa)
+    vm.pdf(scale*x)
+  }
+}
+
+private class VonMisesEvaluator(name: String,
+                                kappa: Double,
+                                scale: Double,
+                                points: Array[Double])
+  extends Transformer[Double, Unit, Unit](name) {
+
+  private val pMax = points.max
+  private val upperBound = 2*math.Pi/scale
+  require(pMax >= 0 && pMax <= upperBound,
+    "point=%.3f not in the range [0, %.3f] (given by [0,2*pi/scale])".format(
+      pMax, upperBound)
+  )
+  override val aggregator: Aggregator[Double, Unit, Unit] = Aggregators.unit[Double]
+  override def featureDimension(c: Unit): Int = points.length
+  override def featureNames(c: Unit): Seq[String] = names(points.length).toSeq
+
+  override def buildFeatures(a: Option[Double], c: Unit, fb: FeatureBuilder[_]): Unit = a match {
+    case Some(mu) => {
+      require(mu >= 0 && mu <= upperBound,
+        "mu=%.3f not in the range [0, %.3f] (given by [0,2*pi/scale])".format(
+          mu, upperBound)
+      )
+      points.zipWithIndex.foreach { case (p: Double, i: Int) =>
+        val v = VonMisesEvaluator.getProbability(p, mu, kappa, scale)
+        fb.add(nameAt(i), v)
+      }
+    }
+    case None => fb.skip(points.length)
+  }
+
+  override def encodeAggregator(c: Option[Unit]): Option[String] = c.map(_ => "")
+  override def decodeAggregator(s: Option[String]): Option[Unit] = s.map(_ => ())
+  override def params: Map[String, String] =
+    Map("points" -> points.mkString("[", ",", "]"),
+      "kappa" -> kappa.toString,
+      "scale" -> scale.toString)
+}

--- a/core/src/test/scala/com/spotify/featran/examples/Example.scala
+++ b/core/src/test/scala/com/spotify/featran/examples/Example.scala
@@ -25,7 +25,7 @@ import org.scalacheck._
 
 object Example {
 
-  case class Record(b: Boolean, f: Float, d1: Double, d2: Option[Double],
+  case class Record(b: Boolean, f: Float, d1: Double, d2: Option[Double], d3: Double,
                     s1: String, s2: List[String])
 
   // Random generator for Record
@@ -34,10 +34,11 @@ object Example {
     f <- Arbitrary.arbitrary[Float]
     d1 <- Arbitrary.arbitrary[Double]
     d2 <- Arbitrary.arbitrary[Option[Double]]
+    d3 <- Gen.choose(0, 24)
     s1 <- Gen.alphaStr.map(_.take(5))
     n <- Gen.choose(0, 10)
     s2 <- Gen.listOfN(n, Gen.alphaStr.map(_.take(5)))
-  } yield Record(b, f, d1, d2, s1, s2)
+  } yield Record(b, f, d1, d2, d3, s1, s2)
 
   // Random generator for Seq[Record]
   val recordsGen: Gen[List[Record]] = Gen.listOfN(20, recordGen)
@@ -73,6 +74,10 @@ object Example {
       .required(_.d1)(MinMaxScaler("min_max1"))
       // Scale between custom min and max
       .required(_.d1)(MinMaxScaler("min_max2", 0.0, 100.0))
+      // Evaluate von Mises distribution (mu = d3, kappa = 2) at values 0, 4, .., 24
+      // (rescaled using scale=pi/12 to be in the interval [0,2pi])
+      .required(_.d3)(VonMisesEvaluator("von_mises", 2.0, math.Pi/12,
+        Array(0.0, 4.0, 8.0, 12.0, 16.0, 20.0, 24.0)))
       .required(_.s1)(OneHotEncoder("one_hot"))
       // Normalize vector with default p 2.0
       .required(toArray)(Normalizer("norm1"))

--- a/core/src/test/scala/com/spotify/featran/transformers/VonMisesEvaluatorSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/VonMisesEvaluatorSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.featran.transformers
+
+import breeze.stats.distributions.VonMises
+import org.scalacheck._
+
+object VonMisesEvaluatorSpec extends TransformerProp("VonMisesEvaluator") {
+
+  private val minPoint = 0.0
+  private val maxPoint = 1000.0
+
+  private val scale = 2*math.Pi / maxPoint
+
+  val muGen = Gen.nonEmptyListOf(Gen.choose(minPoint, maxPoint))
+
+  private val pointGen  = Gen.choose(3, 10)
+    .flatMap(n => Gen.listOfN(n, Gen.choose(minPoint, maxPoint)))
+
+  private val kappaGen = Gen.choose(0.0, 100.0)
+
+  property("default") = Prop.forAll(muGen, pointGen, kappaGen) { (m, p, k) =>
+    testValues(m, p, k)
+  }
+
+  def testValues(mu: List[Double], points: List[Double], kappa: Double): Prop = {
+    val dim = points.size
+    val names = (0 until dim).map("vm_" + _)
+    val missing = (0 until dim).map(_ => 0.0)
+
+    val expected = mu.map { mu =>
+      points.map { case (p: Double) =>
+        val vm = VonMises(mu*scale, kappa)
+        vm.pdf(scale*p)
+      }
+    }
+
+    test(VonMisesEvaluator("vm", kappa, scale, points.toArray), mu, names, expected, missing)
+  }
+}


### PR DESCRIPTION
This PR adds a von Mises distribution evaluator as a new transformer. The use case is for converting the time of day to a feature vector that captures the circularity of time.