### PR TITLE
fb.init() should be called once per record

### DIFF
--- a/core/src/main/scala/com/spotify/featran/transformers/HashNHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/HashNHotEncoder.scala
@@ -69,7 +69,6 @@ private class HashNHotEncoder(name: String, hashBucketSize: Int, sizeScalingFact
   override def prepare(a: Seq[String]): HLL = a.map(hllMonoid.toHLL(_)).reduce(hllMonoid.plus)
 
   override def buildFeatures(a: Option[Seq[String]], c: Int, fb: FeatureBuilder[_]): Unit = {
-    fb.init(c)
     a match {
       case Some(xs) =>
         var prev = -1

--- a/core/src/main/scala/com/spotify/featran/transformers/HashNHotWeightedEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/HashNHotWeightedEncoder.scala
@@ -74,7 +74,6 @@ private class HashNHotWeightedEncoder(name: String, hashBucketSize: Int, sizeSca
   override def buildFeatures(a: Option[Seq[WeightedLabel]],
                              c: Int,
                              fb: FeatureBuilder[_]): Unit = {
-    fb.init(c)
     a match {
       case Some(xs) =>
         val weights = new java.util.TreeMap[Int,Double]().asScala.withDefaultValue(0.0)

--- a/core/src/main/scala/com/spotify/featran/transformers/HashOneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/HashOneHotEncoder.scala
@@ -70,7 +70,6 @@ private class HashOneHotEncoder(name: String, hashBucketSize: Int, sizeScalingFa
   override def prepare(a: String): HLL = hllMonoid.toHLL(a)
 
   override def buildFeatures(a: Option[String], c: Int, fb: FeatureBuilder[_]): Unit = {
-    fb.init(c)
     a match {
       case Some(x) =>
         val i = HashEncoder.bucket(x, c)


### PR DESCRIPTION
Fix for #31 

Calls to fb.init() in Hash*HotEncoder causes the length of SparseVector to be set incorrectly since fb.init() should be called once per record.