### PR TITLE
Fix concurrency problem in java and sparse arrays

### DIFF
--- a/java/src/main/scala/com/spotify/featran/java/JavaOps.scala
+++ b/java/src/main/scala/com/spotify/featran/java/JavaOps.scala
@@ -65,10 +65,10 @@ private object JavaOps {
   def featureValuesDouble[T](fe: FeatureExtractor[JList, T]): JList[Array[Double]] =
     fe.featureValues[Array[Double]]
 
-  implicit val floatSparseArrayFB: FeatureBuilder[FloatSparseArray] =
+  implicit def floatSparseArrayFB: FeatureBuilder[FloatSparseArray] =
     implicitly[FeatureBuilder[SparseArray[Float]]]
       .map(a => new FloatSparseArray(a.indices, a.values, a.length))
-  implicit val doubleSparseArrayFB: FeatureBuilder[DoubleSparseArray] =
+  implicit def doubleSparseArrayFB: FeatureBuilder[DoubleSparseArray] =
     implicitly[FeatureBuilder[SparseArray[Double]]]
       .map(a => new DoubleSparseArray(a.indices, a.values, a.length))
 


### PR DESCRIPTION
Memoizing sparse array feature builder fail in concurrent environment
because that builder holds state.