### PR TITLE
add FeatureBuilder benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -231,5 +231,6 @@ lazy val featranJmh: Project = Project(
   classDirectory in Jmh := (classDirectory in Test).value,
   dependencyClasspath in Jmh := (dependencyClasspath in Test).value
 ).dependsOn(
-  core
+  core,
+  tensorflow
 ).enablePlugins(JmhPlugin)

--- a/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
@@ -246,28 +246,10 @@ object FeatureBuilder {
     implicitly[FeatureBuilder[Array[T]]].map(DenseVector(_))
 
   implicit def sparseVectorFB[T: ClassTag : FloatingPoint : Semiring : Zero]
-  : FeatureBuilder[SparseVector[T]] = new FeatureBuilder[SparseVector[T]] {
-    private var dim: Int = _
-    private var offset: Int = 0
-    private val queue: mutable.Queue[(Int, T)] = mutable.Queue.empty
-    private val fp = implicitly[FloatingPoint[T]]
-    override def init(dimension: Int): Unit = {
-      dim = dimension
-      offset = 0
-      queue.clear()
+  : FeatureBuilder[SparseVector[T]] =
+    implicitly[FeatureBuilder[SparseArray[T]]].map { a =>
+      new SparseVector(a.indices, a.values, a.indices.length, a.length)
     }
-    override def add(name: String, value: Double): Unit = {
-      queue.enqueue((offset, fp.fromDouble(value)))
-      offset += 1
-
-    }
-    override def skip(): Unit = offset += 1
-    override def skip(n: Int): Unit = offset += n
-    override def result: SparseVector[T] = {
-      require(offset == dim)
-      SparseVector(dim)(queue: _*)
-    }
-  }
 
   implicit def mapFB[T: ClassTag : FloatingPoint]: FeatureBuilder[Map[String, T]] =
     new FeatureBuilder[Map[String, T]] { self =>

--- a/jmh/src/test/scala/com/spotify/featran/jmh/FeatureBuilderBenchmark.scala
+++ b/jmh/src/test/scala/com/spotify/featran/jmh/FeatureBuilderBenchmark.scala
@@ -1,0 +1,42 @@
+package com.spotify.featran.jmh
+
+import java.util.concurrent.TimeUnit
+
+import breeze.linalg._
+import com.spotify.featran._
+import com.spotify.featran.tensorflow._
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import org.tensorflow.example.Example
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+class FeatureBuilderBenchmark {
+
+  private val names = (750 until 1000).map(_.toString)
+  private val values = (750 until 1000).map(_.toDouble)
+
+  def benchmark[T: FeatureBuilder](bh: Blackhole): Unit = {
+    val fb = implicitly[FeatureBuilder[T]]
+    fb.init(1000)
+    var i = 0
+    while (i < 500) {
+      fb.add(i.toString, i.toDouble)
+      fb.skip()
+      i += 2
+    }
+    fb.skip(250)
+    fb.add(names, values)
+    bh.consume(fb.result)
+  }
+
+  @Benchmark def array(bh: Blackhole): Unit = benchmark[Array[Double]](bh)
+  @Benchmark def seq(bh: Blackhole): Unit = benchmark[Seq[Double]](bh)
+  @Benchmark def sparseArray(bh: Blackhole): Unit = benchmark[SparseArray[Double]](bh)
+  @Benchmark def denseVector(bh: Blackhole): Unit = benchmark[DenseVector[Double]](bh)
+  @Benchmark def sparseVector(bh: Blackhole): Unit = benchmark[SparseVector[Double]](bh)
+  @Benchmark def map(bh: Blackhole): Unit = benchmark[Map[String, Double]](bh)
+  @Benchmark def tensorflow(bh: Blackhole): Unit = benchmark[Example](bh)
+
+}

--- a/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
+++ b/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
@@ -23,7 +23,8 @@ package object tensorflow {
   /**
    * [[FeatureBuilder]] for output as TensorFlow `Example` type.
    */
-  implicit object TensorFlowFeatureBuilder extends FeatureBuilder[tf.Example] {
+  implicit def tensorFlowFeatureBuilder
+  : FeatureBuilder[tf.Example] = new FeatureBuilder[tf.Example] {
     @transient private lazy val fb = tf.Features.newBuilder()
     override def init(dimension: Int): Unit = fb.clear()
     override def add(name: String, value: Double): Unit =
@@ -33,6 +34,7 @@ package object tensorflow {
           .setFloatList(tf.FloatList.newBuilder().addValue(value.toFloat))
           .build())
     override def skip(): Unit = Unit
+    override def skip(n: Int): Unit = Unit
     override def result: tf.Example = tf.Example.newBuilder().setFeatures(fb).build()
   }
 }


### PR DESCRIPTION
```
[info] # Run complete. Total time: 00:02:22
[info] Benchmark                             Mode  Cnt      Score      Error  Units
[info] FeatureBuilderBenchmark.array         avgt   10   9597.619 ± 2103.568  ns/op
[info] FeatureBuilderBenchmark.denseVector   avgt   10   9064.211 ±   77.171  ns/op
[info] FeatureBuilderBenchmark.map           avgt   10  66832.117 ± 2732.898  ns/op
[info] FeatureBuilderBenchmark.seq           avgt   10  13010.496 ±  664.425  ns/op
[info] FeatureBuilderBenchmark.sparseArray   avgt   10   8938.740 ±   96.700  ns/op
[info] FeatureBuilderBenchmark.sparseVector  avgt   10  66165.036 ± 2033.404  ns/op
[info] FeatureBuilderBenchmark.tensorflow    avgt   10  49127.317 ± 2873.874  ns/op
```