### PR TITLE
Feature Spec Extension

### DIFF
--- a/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
@@ -87,6 +87,21 @@ class FeatureSpec[T] private[featran] (private[featran] val features: Array[Feat
   }
 
   /**
+   * Extend this Spec with another Spec but allowing for a function to be called first.
+   * Useful for an existing Spec on a subobject.
+   * @param f Function to apply before calling the extending spec.
+   * @param spec Spec to apply.
+   * @tparam S Type of the extension spec
+   */
+  def extend[S](f: T => S)(spec: FeatureSpec[S]): FeatureSpec[T] = {
+    val composedFeatures = spec.features.map{feature =>
+      val t = feature.transformer.asInstanceOf[Transformer[Any, _, _]]
+      new Feature(f.andThen(feature.f), feature.default, t)
+    }
+    new FeatureSpec[T](this.features ++ composedFeatures, this.crossings ++ spec.crossings)
+  }
+
+  /**
    * Extract features from an input collection.
    *
    * This is done in two steps, a `reduce` step over the collection to aggregate feature summary,

--- a/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
@@ -87,8 +87,8 @@ class FeatureSpec[T] private[featran] (private[featran] val features: Array[Feat
   }
 
   /**
-   * Compose this Spec with another Spec but allowing for a function to be called first.
-   * Useful for an existing Spec on a subobject.
+   * Compose this Spec with another Spec while allowing for a function to be called first.
+   * Useful for reusing an existing Spec with another object.
    * @param spec Spec to apply.
    * @param f Function to apply before calling the extending spec.
    * @tparam S Type of the extension spec

--- a/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
@@ -87,13 +87,13 @@ class FeatureSpec[T] private[featran] (private[featran] val features: Array[Feat
   }
 
   /**
-   * Extend this Spec with another Spec but allowing for a function to be called first.
+   * Compose this Spec with another Spec but allowing for a function to be called first.
    * Useful for an existing Spec on a subobject.
-   * @param f Function to apply before calling the extending spec.
    * @param spec Spec to apply.
+   * @param f Function to apply before calling the extending spec.
    * @tparam S Type of the extension spec
    */
-  def extend[S](f: T => S)(spec: FeatureSpec[S]): FeatureSpec[T] = {
+  def compose[S](spec: FeatureSpec[S])(f: T => S): FeatureSpec[T] = {
     val composedFeatures = spec.features.map{feature =>
       val t = feature.transformer.asInstanceOf[Transformer[Any, _, _]]
       new Feature(f.andThen(feature.f), feature.default, t)

--- a/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
@@ -86,13 +86,13 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
       f.featureValues[Seq[Double]] == xs.map(r => Seq(r.d, r.optD.getOrElse(0.5))))
   }
 
-  property("extend") = Prop.forAll { xs: List[RecordWrapper] =>
+  property("compose") = Prop.forAll { xs: List[RecordWrapper] =>
     val rSpec = FeatureSpec.of[Record]
       .required(_.d)(Identity("id1"))
       .optional(_.optD, Some(0.5))(Identity("id2"))
     val spec = FeatureSpec
       .of[RecordWrapper]
-      .extend(_.record)(rSpec)
+      .compose(rSpec)(_.record)
       .required(_.d)(Identity("id3"))
 
     val f = spec.extract(xs)

--- a/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
@@ -91,7 +91,6 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
       val rSpec = FeatureSpec.of[Record]
         .required(_.d)(Identity("id1"))
         .optional(_.optD, Some(0.5))(Identity("id2"))
-      
       val spec = FeatureSpec
         .of[RecordWrapper]
         .extend(_.record)(rSpec)

--- a/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
@@ -25,9 +25,15 @@ import scala.util.Try
 object FeatureSpecSpec extends Properties("FeatureSpec") {
 
   case class Record(d: Double, optD: Option[Double])
+  case class RecordWrapper(record: Record, d: Double)
 
   implicit val arbRecords: Arbitrary[List[Record]] = Arbitrary {
     Gen.listOfN(100, Arbitrary.arbitrary[(Double, Option[Double])].map(Record.tupled))
+  }
+
+  implicit val arbWrapperRecords: Arbitrary[List[RecordWrapper]] = Arbitrary {
+    Gen.listOfN(100, Arbitrary.arbitrary[(Double, Double, Option[Double])]
+      .map{case(d1, d2, od) => RecordWrapper(Record(d2, od), d1)})
   }
 
   private val id = Identity("id")
@@ -78,6 +84,31 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
     Prop.all(
       f.featureNames == Seq(Seq("id1", "id2")),
       f.featureValues[Seq[Double]] == xs.map(r => Seq(r.d, r.optD.getOrElse(0.5))))
+  }
+
+  property("extend") = Prop.forAll { xs: List[RecordWrapper] =>
+    try {
+      val rSpec = FeatureSpec.of[Record]
+        .required(_.d)(Identity("id1"))
+        .optional(_.optD, Some(0.5))(Identity("id2"))
+      
+      val spec = FeatureSpec
+        .of[RecordWrapper]
+        .extend(_.record)(rSpec)
+        .required(_.d)(Identity("id3"))
+
+      val f = spec.extract(xs)
+
+      Prop.all(
+        f.featureNames == Seq(Seq("id1", "id2", "id3")),
+        f.featureValues[Seq[Double]] == xs.map { r =>
+          Seq(r.record.d, r.record.optD.getOrElse(0.5), r.d)
+        })
+    } catch {
+      case e: Exception =>
+        e.printStackTrace()
+        throw e
+    }
   }
 
   property("original") = Prop.forAll { xs: List[Record] =>

--- a/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
@@ -87,27 +87,21 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
   }
 
   property("extend") = Prop.forAll { xs: List[RecordWrapper] =>
-    try {
-      val rSpec = FeatureSpec.of[Record]
-        .required(_.d)(Identity("id1"))
-        .optional(_.optD, Some(0.5))(Identity("id2"))
-      val spec = FeatureSpec
-        .of[RecordWrapper]
-        .extend(_.record)(rSpec)
-        .required(_.d)(Identity("id3"))
+    val rSpec = FeatureSpec.of[Record]
+      .required(_.d)(Identity("id1"))
+      .optional(_.optD, Some(0.5))(Identity("id2"))
+    val spec = FeatureSpec
+      .of[RecordWrapper]
+      .extend(_.record)(rSpec)
+      .required(_.d)(Identity("id3"))
 
-      val f = spec.extract(xs)
+    val f = spec.extract(xs)
 
-      Prop.all(
-        f.featureNames == Seq(Seq("id1", "id2", "id3")),
-        f.featureValues[Seq[Double]] == xs.map { r =>
-          Seq(r.record.d, r.record.optD.getOrElse(0.5), r.d)
-        })
-    } catch {
-      case e: Exception =>
-        e.printStackTrace()
-        throw e
-    }
+    Prop.all(
+      f.featureNames == Seq(Seq("id1", "id2", "id3")),
+      f.featureValues[Seq[Double]] == xs.map { r =>
+        Seq(r.record.d, r.record.optD.getOrElse(0.5), r.d)
+      })
   }
 
   property("original") = Prop.forAll { xs: List[Record] =>


### PR DESCRIPTION
This method should hopefully make it easier to share feature specs when you have a spec that depends on some sub type of a larger object.  The idea is that you have some custom class that is specific to your domain you may have sub object that you share across projects.

The function in the method allows for the mapping between the higher level object and the reusable spec object.