### PR TITLE
Add support for TFRecordSpec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,10 +24,11 @@ val circeVersion = "0.8.0"
 val commonsMathVersion = "3.6.1"
 val flinkVersion = "1.4.0"
 val hadoopVersion = "2.8.0"
+val hamcrestVersion = "1.3"
 val scalacheckVersion = "1.13.5"
 val scalatestVersion = "3.0.4"
 val scaldingVersion = "0.17.3"
-val scioVersion = "0.4.6"
+val scioVersion = "0.4.7"
 val sparkVersion = "2.2.1"
 val tensorflowVersion = "1.4.0"
 
@@ -174,11 +175,14 @@ lazy val scio: Project = Project(
   description := "Feature Transformers - Scio",
   libraryDependencies ++= Seq(
     "com.spotify" %% "scio-core" % scioVersion % "provided",
-    "com.spotify" %% "scio-test" % scioVersion % "test"
+    "com.spotify" %% "scio-tensorflow" % scioVersion % "provided",
+    "com.spotify" %% "scio-test" % scioVersion % "test",
+    "org.hamcrest" % "hamcrest-all" % hamcrestVersion % "test"
   )
 ).dependsOn(
   core,
-  core % "test->test"
+  core % "test->test",
+  tensorflow % "test"
 )
 
 lazy val spark: Project = Project(

--- a/scio/src/main/scala/com/spotify/featran/scio/TFExampleScollectionFunctions.scala
+++ b/scio/src/main/scala/com/spotify/featran/scio/TFExampleScollectionFunctions.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.featran.scio
+
+import com.spotify.featran.{FeatureExtractor, MultiFeatureExtractor}
+import com.spotify.scio.io.Tap
+import com.spotify.scio.tensorflow._
+import com.spotify.scio.values.SCollection
+import org.apache.beam.sdk.io.Compression
+import org.tensorflow.{example => tf}
+import scala.concurrent.Future
+
+private object FeatranTFRecordSpec {
+
+  def fromFeatureSpec(featureNames: SCollection[Seq[String]]): TFRecordSpec = {
+    TFRecordSpec.fromSColSeqFeatureInfo(
+      featureNames.map(_.map(n => FeatureInfo(n, FeatureKind.FloatList, Map()))))
+  }
+
+  def fromMultiSpec(featureNames: SCollection[Seq[Seq[String]]]): TFRecordSpec = {
+    val featureInfos = featureNames.map(_.zipWithIndex.flatMap {
+      case (sss, i) => sss.map(n =>
+        FeatureInfo(n, FeatureKind.FloatList, Map("multispec-id" -> i.toString)))
+    })
+    TFRecordSpec.fromSColSeqFeatureInfo(featureInfos)
+  }
+}
+
+private[featran] class TFExampleSCollectionFunctions[T <: tf.Example](val self: SCollection[T]) {
+
+  import com.spotify.scio.tensorflow._
+
+  /**
+   *
+   * Save this SCollection of [[tf.Example]] as TensorFlow TFRecord files.
+   * @param fe FeatureExtractor, obtained from Featran after calling extract on a
+   *           [[com.spotify.featran.FeatureSpec]]
+   * @group output
+   */
+  def saveAsTfExampleFile(path: String,
+                          fe: FeatureExtractor[SCollection, _]):
+  (Future[Tap[tf.Example]], Future[Tap[String]]) = {
+    saveAsTfExampleFile(path, fe, Compression.UNCOMPRESSED)
+  }
+
+  /**
+   * Save this SCollection of [[tf.Example]] as TensorFlow TFRecord files.
+   *
+   * @param fe FeatureExtractor, obtained from Featran after calling extract on a
+   *           [[com.spotify.featran.FeatureSpec]]
+   * @group output
+   */
+  def saveAsTfExampleFile(path: String,
+                          fe: FeatureExtractor[SCollection, _],
+                          compression: Compression):
+  (Future[Tap[tf.Example]], Future[Tap[String]]) = {
+    self.saveAsTfExampleFile(path,
+      FeatranTFRecordSpec.fromFeatureSpec(fe.featureNames),
+      compression = compression)
+  }
+
+}
+
+private[featran] class SeqTFExampleSCollectionFunctions[T <: tf.Example]
+(@transient val self: SCollection[Seq[T]]) extends Serializable {
+
+  import com.spotify.scio.tensorflow._
+
+  def mergeExamples(e: Seq[tf.Example]): tf.Example = e
+    .foldLeft(tf.Example.newBuilder)((b, i) => b.mergeFrom(i))
+    .build()
+
+  /**
+   * Merge each [[Seq]] of [[tf.Example]] and save them as TensorFlow TFRecord files.
+   * Caveat: If some feature names are repeated in different feature specs, they will be collapsed.
+   *
+   * @param fe FeatureExtractor, obtained from Featran after calling extract on a
+   *           [[com.spotify.featran.MultiFeatureSpec]]
+   * @group output
+   */
+  def saveAsTfExampleFile(path: String,
+                          fe: MultiFeatureExtractor[SCollection, _]):
+  (Future[Tap[tf.Example]], Future[Tap[String]]) = {
+    saveAsTfExampleFile(path, fe, Compression.UNCOMPRESSED)
+  }
+
+  /**
+   * Merge each [[Seq]] of [[tf.Example]] and save them as TensorFlow TFRecord files.
+   * Caveat: If some feature names are repeated in different feature specs, they will be collapsed.
+   *
+   * @param fe FeatureExtractor, obtained from Featran after calling extract on a
+   *           [[com.spotify.featran.MultiFeatureSpec]]
+   * @group output
+   */
+  def saveAsTfExampleFile(path: String,
+                          fe: MultiFeatureExtractor[SCollection, _],
+                          compression: Compression):
+  (Future[Tap[tf.Example]], Future[Tap[String]]) = {
+    self.map(mergeExamples)
+      .saveAsTfExampleFile(path,
+        FeatranTFRecordSpec.fromMultiSpec(fe.featureNames),
+        compression = compression)
+  }
+
+}

--- a/scio/src/main/scala/com/spotify/featran/scio/package.scala
+++ b/scio/src/main/scala/com/spotify/featran/scio/package.scala
@@ -18,6 +18,7 @@
 package com.spotify.featran
 
 import com.spotify.scio.values.SCollection
+import org.tensorflow.{example => tf}
 
 import scala.reflect.ClassTag
 
@@ -28,9 +29,23 @@ package object scio {
    */
   implicit object ScioCollectionType extends CollectionType[SCollection] {
     override def map[A, B: ClassTag](ma: SCollection[A], f: (A) => B): SCollection[B] = ma.map(f)
+
     override def reduce[A](ma: SCollection[A], f: (A, A) => A): SCollection[A] = ma.reduce(f)
+
     override def cross[A, B: ClassTag](ma: SCollection[A],
                                        mb: SCollection[B]): SCollection[(A, B)] = ma.cross(mb)
   }
 
+  import scala.language.implicitConversions
+
+  /** Companion for [[SCollection]] of [[tf.Example]] to enable use of saveAsTfExampleFile. */
+  implicit def makeTFExampleSCollectionFunctions[T <: tf.Example](s: SCollection[T])
+  : TFExampleSCollectionFunctions[T] = new TFExampleSCollectionFunctions(s)
+
+  /**
+   * Companion for [[SCollection]] of [[Seq]] of [[tf.Example]] to enable use of
+   * saveAsTfExampleFile.
+   **/
+  implicit def makeSeqTFExampleSCollectionFunctions[T <: tf.Example](s: SCollection[Seq[T]])
+  : SeqTFExampleSCollectionFunctions[T] = new SeqTFExampleSCollectionFunctions(s)
 }

--- a/scio/src/test/scala/com/spotify/featran/scio/TFExampleSCollectionFunctionsTest.scala
+++ b/scio/src/test/scala/com/spotify/featran/scio/TFExampleSCollectionFunctionsTest.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.featran.scio
+
+import com.spotify.featran.tensorflow._
+import com.spotify.featran.transformers.Identity
+import com.spotify.featran.{FeatureSpec, MultiFeatureSpec}
+import com.spotify.scio._
+import com.spotify.scio.tensorflow.TFExampleIO
+import com.spotify.scio.testing.{PipelineSpec, TextIO}
+import org.tensorflow.{example => tf}
+
+case class TrainingPoint(x1: Double, label: Double)
+
+object FeatureSpecJob {
+
+  def main(argv: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(argv)
+
+    val featureSpec = FeatureSpec.of[TrainingPoint]
+      .required(_.x1)(Identity("x1"))
+      .required(_.label)(Identity("label"))
+
+    val collection = sc.textFile(args("input"))
+      .map(_.split(","))
+      .collect { case Array(x1, l) => TrainingPoint(x1.toDouble, l.toDouble) }
+
+    val features = featureSpec.extract(collection)
+
+    val (train, test) = features
+      .featureValues[tf.Example]
+      .randomSplit(.9)
+
+    train.saveAsTfExampleFile(args("output") + "/train", features)
+    test.saveAsTfExampleFile(args("output") + "/test", features)
+
+    sc.close()
+  }
+}
+
+object MultiSpecJob {
+
+  def main(argv: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(argv)
+
+    val features = FeatureSpec.of[TrainingPoint]
+      .required(_.x1)(Identity("x1"))
+
+    val label = FeatureSpec.of[TrainingPoint]
+      .required(_.label)(Identity("label"))
+
+    val collection = sc.textFile(args("input"))
+      .map(_.split(","))
+      .collect { case Array(x1, l) => TrainingPoint(x1.toDouble, l.toDouble) }
+
+    val dataset = MultiFeatureSpec(features, label)
+      .extract(collection)
+
+    val (train, test) = dataset
+      .featureValues[tf.Example]
+      .randomSplit(.9)
+
+    train.saveAsTfExampleFile(args("output") + "/train", dataset)
+    test.saveAsTfExampleFile(args("output") + "/test", dataset)
+
+    sc.close()
+  }
+}
+
+class TFExampleSCollectionFunctionsTest extends PipelineSpec {
+
+  val n = 10000
+  val in = 0.to(2 * n, 2).map(i => "%d,%d".format(i, i + 1))
+
+  val tfRecordSpec =
+    """{"version":1,""" +
+      """"features":[{"name":"x1","kind":"FloatList","tags":{}},""" +
+      """{"name":"label","kind":"FloatList","tags":{}}],""" +
+      """"compression":"UNCOMPRESSED"}"""
+
+  "FeatureSpecJob" should "work" in {
+    JobTest[FeatureSpecJob.type]
+      .args("--input=in.txt", "--output=out")
+      .input(TextIO("in.txt"), in)
+      .output(TextIO("out/train/_tf_record_spec.json"))(_ should containSingleValue(tfRecordSpec))
+      .output(TextIO("out/test/_tf_record_spec.json"))(_ should containSingleValue(tfRecordSpec))
+      .output(TFExampleIO("out/train"))(_.count should forAll[Long](c => c > 8500 && c < 9500))
+      .output(TFExampleIO("out/test"))(_.count should forAll[Long](c => c > 500 && c < 1500))
+      .run()
+  }
+
+  val tfRecordMSpec =
+    """{"version":1,""" +
+      """"features":[{"name":"x1","kind":"FloatList","tags":{"multispec-id":"0"}},""" +
+      """{"name":"label","kind":"FloatList","tags":{"multispec-id":"1"}}],""" +
+      """"compression":"UNCOMPRESSED"}"""
+
+  "MultiSpecJob" should "work" in {
+    JobTest[MultiSpecJob.type]
+      .args("--input=in.txt", "--output=out")
+      .input(TextIO("in.txt"), in)
+      .output(TextIO("out/train/_tf_record_spec.json"))(_ should containSingleValue(tfRecordMSpec))
+      .output(TextIO("out/test/_tf_record_spec.json"))(_ should containSingleValue(tfRecordMSpec))
+      .output(TFExampleIO("out/train"))(_.count should forAll[Long](c => c > 8500 && c < 9500))
+      .output(TFExampleIO("out/test"))(_.count should forAll[Long](c => c > 500 && c < 1500))
+      .run()
+  }
+
+}


### PR DESCRIPTION
**DO NOT MERGE YET: https://github.com/spotify/scio/pull/990 should be merged first.**

Add `TFRecordSpec` support for both `FeatureSpec` and `MultiFeatureSpec`.

Enables this convient API:
```scala
val dataset = MultiFeatureSpec(features, label)
  .extract(collection)

val (train, test) = dataset
  .featureValues[tf.Example]
  .randomSplit(.9)

train.saveAsTfExampleFile(args("output") + "/train", dataset)
test.saveAsTfExampleFile(args("output") + "/test", dataset)
```

**Sibling PR: https://github.com/spotify/spotify-tensorflow/pull/13**