### PR TITLE
PositionEncoder Transformer

### DIFF
--- a/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
@@ -33,6 +33,7 @@ object FeatureRejection {
   case class Unseen(labels: Set[String]) extends FeatureRejection
   case class WrongDimension(expected: Int, actual: Int) extends FeatureRejection
   case class Outlier(actual: Double) extends FeatureRejection
+  case object Collision extends FeatureRejection
 }
 
 /**

--- a/core/src/main/scala/com/spotify/featran/transformers/PositionEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/PositionEncoder.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.featran.transformers
 
 import com.spotify.featran.{FeatureBuilder, FeatureRejection}

--- a/core/src/main/scala/com/spotify/featran/transformers/PositionEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/PositionEncoder.scala
@@ -22,19 +22,19 @@ import com.spotify.featran.{FeatureBuilder, FeatureRejection}
 import scala.collection.SortedMap
 
 /**
-  * Transform a collection of categorical features to a single value that is the position
-  * of that feature within the complete set of categories.
-  *
-  * Missing values are transformed to zero. Thought may need to be done on how to reject these
-  * since the position can overlap the first categorical dimension.
-  *
-  * When using aggregated feature summary from a previous session, unseen labels are ignored and
-  * [[FeatureRejection.Unseen]] rejections are reported.
-  */
+ * Transform a collection of categorical features to a single value that is the position
+ * of that feature within the complete set of categories.
+ *
+ * Missing values are transformed to zero so may collide with the first position. Rejections can be
+ * use to remove this case.
+ *
+ * When using aggregated feature summary from a previous session, unseen labels are ignored and
+ * [[FeatureRejection.Unseen]] rejections are reported.
+ */
 object PositionEncoder {
   /**
-    * Create a new [[PositionEncoder]] instance.
-    */
+   * Create a new [[PositionEncoder]] instance.
+   */
   def apply(name: String): Transformer[String, Set[String], SortedMap[String, Int]] =
     new PositionEncoder(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/PositionEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/PositionEncoder.scala
@@ -1,0 +1,44 @@
+package com.spotify.featran.transformers
+
+import com.spotify.featran.{FeatureBuilder, FeatureRejection}
+
+import scala.collection.SortedMap
+
+/**
+  * Transform a collection of categorical features to a single value that is the position
+  * of that feature within the complete set of categories.
+  *
+  * Missing values are transformed to zero. Thought may need to be done on how to reject these
+  * since the position can overlap the first categorical dimension.
+  *
+  * When using aggregated feature summary from a previous session, unseen labels are ignored and
+  * [[FeatureRejection.Unseen]] rejections are reported.
+  */
+object PositionEncoder {
+  /**
+    * Create a new [[PositionEncoder]] instance.
+    */
+  def apply(name: String): Transformer[String, Set[String], SortedMap[String, Int]] =
+    new PositionEncoder(name)
+}
+
+private class PositionEncoder(name: String) extends BaseHotEncoder[String](name) {
+  override def prepare(a: String): Set[String] = Set(a)
+  override def featureDimension(c: SortedMap[String, Int]): Int = 1
+  override def featureNames(c: SortedMap[String, Int]): Seq[String] = Seq(name)
+  override def buildFeatures(a: Option[String],
+                             c: SortedMap[String, Int],
+                             fb: FeatureBuilder[_]): Unit = {
+    a match {
+      case Some(k) => c.get(k) match {
+        case Some(v) => fb.add(name, v.toDouble)
+        case None =>
+          fb.skip(1)
+          fb.reject(this, FeatureRejection.Unseen(Set(k)))
+      }
+      case None =>
+        fb.skip(1)
+        fb.reject(this, FeatureRejection.Collision)
+    }
+  }
+}

--- a/core/src/test/scala/com/spotify/featran/Fixtures.scala
+++ b/core/src/test/scala/com/spotify/featran/Fixtures.scala
@@ -83,6 +83,7 @@ object Fixtures {
     .required(_.s3)(NHotWeightedEncoder("n-hot-weighted"))
     .required(_.v)(Normalizer("norm"))
     .required(_.s1)(OneHotEncoder("one-hot"))
+    .required(_.s1)(PositionEncoder("position"))
     .required(_.v)(PolynomialExpansion("poly"))
     .required(_.x)(QuantileDiscretizer("quantile"))
     .required(_.x)(QuantileOutlierRejector("quantile_filter"))

--- a/core/src/test/scala/com/spotify/featran/transformers/PositionEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/PositionEncoderSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.featran.transformers
 
 import org.scalacheck.{Arbitrary, Gen, Prop}

--- a/core/src/test/scala/com/spotify/featran/transformers/PositionEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/PositionEncoderSpec.scala
@@ -1,0 +1,17 @@
+package com.spotify.featran.transformers
+
+import org.scalacheck.{Arbitrary, Gen, Prop}
+
+class PositionEncoderSpec extends TransformerProp("PositionEncoder") {
+
+  private implicit val labelArb = Arbitrary(Gen.alphaStr)
+
+  property("default") = Prop.forAll { xs: List[String] =>
+    val cats = xs.distinct.sorted
+    val expected =
+      xs.map(s => Seq(cats.zipWithIndex.find(c => s == c._1).map(_._2).getOrElse(0).toDouble))
+    val oob = List(("s1", Seq(0.0)), ("s2", Seq(0.0))) // unseen labels
+    test(PositionEncoder("position"), xs, List("position"), expected, Seq(0.0), oob)
+  }
+
+}

--- a/examples/src/main/scala/Examples.scala
+++ b/examples/src/main/scala/Examples.scala
@@ -82,6 +82,7 @@ object Examples {
 
       // One hot, n-hot and n-hot weighted encoders
       .required(_.s1)(OneHotEncoder("one_hot"))
+      .required(_.s1)(PositionEncoder("position"))
       .required(_.s2)(NHotEncoder("n_hot"))
       .required(_.s2.map(s => WeightedLabel(s, 0.5)))(NHotWeightedEncoder("n_hot_weighted"))
 


### PR DESCRIPTION
Fixes #91.  General idea is that instead of outputting a binary vector the transformer instead outputs the position of the category in the sorted sets of possible values. The one small quirk of this though is that missing data will collide with the 0 position.  For labels the first class having a position of 0 seems standard so I don't think we want 1 index.

To work around collisions there is now a new rejection type called Collide that users can remove if they know they don't expect missing values in the category.

The thought is that this transformer would mostly be used around labels for supervised problems so removing rows with missing labels may be reasonable.