### PR TITLE
Slhansen/default option

### DIFF
--- a/core/src/main/scala/com/spotify/featran/transformers/HeavyHitters.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/HeavyHitters.scala
@@ -42,9 +42,9 @@ object HeavyHitters {
    * @param heavyHittersCount number of heavy hitters to keep track of
    * @param eps one-sided error bound on the error of each point query, i.e. frequency estimate
    * @param delta a bound on the probability that a query estimate does not lie within some small
-   *              interval (an interval that depends on `eps`) around the truth.
+   *              interval (an interval that depends on `eps`) around the truth
    * @param seed a seed to initialize the random number generator used to create the pairwise
-   *             independent hash functions.
+   *             independent hash functions
    */
   def apply(name: String, heavyHittersCount: Int,
             eps: Double = 0.001,

--- a/core/src/main/scala/com/spotify/featran/transformers/NGrams.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/NGrams.scala
@@ -51,7 +51,7 @@ object NGrams {
 }
 
 private class NGrams(name: String, val low: Int, val high: Int, val sep: String)
-  extends NHotEncoder(name) {
+  extends NHotEncoder(name, false) {
   override def prepare(a: Seq[String]): Set[String] = ngrams(a).toSet
 
   override def buildFeatures(a: Option[Seq[String]],

--- a/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
@@ -20,8 +20,8 @@ package com.spotify.featran.transformers
 import com.spotify.featran.{FeatureBuilder, FeatureRejection}
 
 import scala.collection.SortedMap
-import scala.collection.mutable.{Map => MMap}
-import scala.collection.mutable.{Set => MSet}
+import scala.collection.mutable.{Map => MMap, Set => MSet}
+
 /**
  * Weighted label. Also can be thought as a weighted value in a named sparse vector.
  */
@@ -37,43 +37,39 @@ case class WeightedLabel(name: String, value: Double)
  * Missing values are either transformed to zero vectors or encoded as a missing value.
  *
  * When using aggregated feature summary from a previous session, unseen labels are either
- * transformed to zero vectors or encoded as a missing value (if missingValueOpt is provided) and
+ * transformed to zero vectors or encoded as __unknown__ (if encodeMissingValue is true) and
  * [FeatureRejection.Unseen]] rejections are reported.
  */
 object NHotWeightedEncoder {
   /**
    * Create a new [[NHotWeightedEncoder]] instance.
    */
-  def apply(name: String, missingValueOpt: Option[String] = None)
+  def apply(name: String, encodeMissingValue: Boolean = false)
   : Transformer[Seq[WeightedLabel], Set[String], SortedMap[String, Int]] =
-    new NHotWeightedEncoder(name, missingValueOpt)
+    new NHotWeightedEncoder(name, encodeMissingValue)
 
-  def apply(name: String, missingValue: String)
-  : Transformer[Seq[WeightedLabel], Set[String], SortedMap[String, Int]] =
-    new NHotWeightedEncoder(name, Some(missingValue))
-
-  // extra definition for java compatibility
+  /** Extra definition for java compatibility. */
   def apply(name: String)
   : Transformer[Seq[WeightedLabel], Set[String], SortedMap[String, Int]] =
-    new NHotWeightedEncoder(name, None)
+    new NHotWeightedEncoder(name, false)
 }
 
-private class NHotWeightedEncoder(name: String, missingValueOpt: Option[String] = None)
-  extends BaseHotEncoder[Seq[WeightedLabel]](name, missingValueOpt) {
+private class NHotWeightedEncoder(name: String, encodeMissingValue: Boolean = false)
+  extends BaseHotEncoder[Seq[WeightedLabel]](name, encodeMissingValue) {
   override def prepare(a: Seq[WeightedLabel]): Set[String] = Set(a.map(_.name): _*)
 
   /**
-    * Transform sequence of weighted labels to a map where the key is the label name and the
-    * value is the weight value. If missingValueOpt is provided then check to see if any of
-    * the label names are not in the SortedMap. If this is the case then an additional
-    * element is added to the list where the key is the missing token name and the value is the
-    * sum over all weights of the missing labels.
-    */
+   * Transform sequence of weighted labels to a map where the key is the label name and the
+   * value is the weight value. If encodeMissingValue is true then check to see if any of
+   * the label names are not in the SortedMap. If this is the case then an additional
+   * element is added to the list where the key is __unknown__ and the value is the
+   * sum over all the weights of the missing labels.
+   */
   def getWeights(xs: Seq[WeightedLabel], c: SortedMap[String, Int]): MMap[String, Double] = {
     val weights = MMap.empty[String, Double].withDefaultValue(0.0)
     xs.foreach(x => weights(x.name) += x.value)
-    missingValueOpt match {
-      case Some(missingValueToken) => {
+    encodeMissingValue match {
+      case true => {
         // check if an item is unseen
         val missingKeys = weights.keySet.filter(!c.contains(_)).toSet
         missingKeys.size match {
@@ -85,7 +81,7 @@ private class NHotWeightedEncoder(name: String, missingValueOpt: Option[String] 
             weights
         }
       }
-      case None => weights
+      case false => weights
     }
   }
 

--- a/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
@@ -34,29 +34,66 @@ case class WeightedLabel(name: String, value: Double)
  * Weights of the same labels in a row are summed instead of 1.0 as is the case with the normal
  * [[NHotEncoder]].
  *
- * Missing values are transformed to zero vectors.
+ * Missing values are either transformed to zero vectors or encoded as a missing value.
  *
- * When using aggregated feature summary from a previous session, unseen labels are ignored and
- * [[FeatureRejection.Unseen]] rejections are reported.
+ * When using aggregated feature summary from a previous session, unseen labels are either
+ * transformed to zero vectors or encoded as a missing value (if missingValueOpt is provided) and
+ * [FeatureRejection.Unseen]] rejections are reported.
  */
 object NHotWeightedEncoder {
   /**
    * Create a new [[NHotWeightedEncoder]] instance.
    */
+  def apply(name: String, missingValueOpt: Option[String] = None)
+  : Transformer[Seq[WeightedLabel], Set[String], SortedMap[String, Int]] =
+    new NHotWeightedEncoder(name, missingValueOpt)
+
+  def apply(name: String, missingValue: String)
+  : Transformer[Seq[WeightedLabel], Set[String], SortedMap[String, Int]] =
+    new NHotWeightedEncoder(name, Some(missingValue))
+
+  // extra definition for java compatibility
   def apply(name: String)
   : Transformer[Seq[WeightedLabel], Set[String], SortedMap[String, Int]] =
-    new NHotWeightedEncoder(name)
+    new NHotWeightedEncoder(name, None)
 }
 
-private class NHotWeightedEncoder(name: String) extends BaseHotEncoder[Seq[WeightedLabel]](name) {
+private class NHotWeightedEncoder(name: String, missingValueOpt: Option[String] = None)
+  extends BaseHotEncoder[Seq[WeightedLabel]](name, missingValueOpt) {
   override def prepare(a: Seq[WeightedLabel]): Set[String] = Set(a.map(_.name): _*)
+
+  /**
+    * Transform sequence of weighted labels to a map where the key is the label name and the
+    * value is the weight value. If missingValueOpt is provided then check to see if any of
+    * the label names are not in the SortedMap. If this is the case then an additional
+    * element is added to the list where the key is the missing token name and the value is the
+    * sum over all weights of the missing labels.
+    */
+  def getWeights(xs: Seq[WeightedLabel], c: SortedMap[String, Int]): MMap[String, Double] = {
+    val weights = MMap.empty[String, Double].withDefaultValue(0.0)
+    xs.foreach(x => weights(x.name) += x.value)
+    missingValueOpt match {
+      case Some(missingValueToken) => {
+        // check if an item is unseen
+        val missingKeys = weights.keySet.filter(!c.contains(_)).toSet
+        missingKeys.size match {
+          case 0 => weights
+          case _ =>
+            // sum weights of missing items
+            val defaultValue = xs.filter(x => missingKeys.contains(x.name)).map(_.value).sum
+            weights(missingValueToken) += defaultValue
+            weights
+        }
+      }
+      case None => weights
+    }
+  }
+
   override def buildFeatures(a: Option[Seq[WeightedLabel]],
                              c: SortedMap[String, Int],
                              fb: FeatureBuilder[_]): Unit = a match {
     case Some(xs) =>
-      val weights = MMap.empty[String, Double].withDefaultValue(0.0)
-      xs.foreach(x => weights(x.name) += x.value)
-
+      val weights = getWeights(xs, c)
       val keys = weights.keySet.toList.sorted
       var prev = -1
       var totalSeen = MSet[String]()
@@ -78,6 +115,6 @@ private class NHotWeightedEncoder(name: String) extends BaseHotEncoder[Seq[Weigh
         val unseen = keys.toSet -- totalSeen
         fb.reject(this, FeatureRejection.Unseen(unseen))
       }
-    case None => fb.skip(c.size)
+    case None => addMissingItem(c, fb)
   }
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/OneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/OneHotEncoder.scala
@@ -77,7 +77,7 @@ object MissingValue {
 private abstract class BaseHotEncoder[A](name: String, encodeMissingValue: Boolean = false)
   extends Transformer[A, Set[String], SortedMap[String, Int]](name) {
 
-  val missingValueToken = MissingValue.missingValueToken
+  private val missingValueToken = MissingValue.missingValueToken
 
   def prepare(a: A): Set[String]
 

--- a/core/src/main/scala/com/spotify/featran/transformers/OneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/OneHotEncoder.scala
@@ -28,21 +28,34 @@ import scala.collection.SortedMap
  * Transform a collection of categorical features to binary columns, with at most a single
  * one-value.
  *
- * Missing values are transformed to zero vectors.
+ * Missing values are either transformed to zero vectors or encoded as a missing value.
  *
- * When using aggregated feature summary from a previous session, unseen labels are ignored and
- * [[FeatureRejection.Unseen]] rejections are reported.
+ * When using aggregated feature summary from a previous session, unseen labels are either
+ * transformed to zero vectors or encoded as a missing value (if missingValueOpt is provided) and
+ * [FeatureRejection.Unseen]] rejections are reported.
  */
 object OneHotEncoder {
   /**
-   * Create a new [[OneHotEncoder]] instance.
-   */
-  def apply(name: String): Transformer[String, Set[String], SortedMap[String, Int]] =
-    new OneHotEncoder(name)
+    * Create a new [[OneHotEncoder]] instance.
+    */
+  def apply(name: String, missingValueOpt: Option[String] = None):
+  Transformer[String, Set[String], SortedMap[String, Int]] =
+    new OneHotEncoder(name, missingValueOpt)
+
+  def apply(name: String, missingValue: String):
+  Transformer[String, Set[String], SortedMap[String, Int]] =
+    new OneHotEncoder(name, Some(missingValue))
+
+  // extra definition for java compatibility
+  def apply(name: String):
+  Transformer[String, Set[String], SortedMap[String, Int]] =
+    new OneHotEncoder(name, None)
 }
 
-private class OneHotEncoder(name: String) extends BaseHotEncoder[String](name) {
+private class OneHotEncoder(name: String, missingValueOpt: Option[String] = None)
+  extends BaseHotEncoder[String](name, missingValueOpt) {
   override def prepare(a: String): Set[String] = Set(a)
+
   override def buildFeatures(a: Option[String],
                              c: SortedMap[String, Int],
                              fb: FeatureBuilder[_]): Unit = {
@@ -53,23 +66,36 @@ private class OneHotEncoder(name: String) extends BaseHotEncoder[String](name) {
           fb.add(name + '_' + k, 1.0)
           fb.skip(math.max(0, c.size - v - 1))
         case None =>
-          fb.skip(c.size)
+          addMissingItem(c, fb)
           fb.reject(this, FeatureRejection.Unseen(Set(k)))
       }
-      case None => fb.skip(c.size)
+      case None => addMissingItem(c, fb)
     }
   }
 }
 
-private abstract class BaseHotEncoder[A](name: String)
+private abstract class BaseHotEncoder[A](name: String, missingValueOpt: Option[String] = None)
   extends Transformer[A, Set[String], SortedMap[String, Int]](name) {
 
   def prepare(a: A): Set[String]
 
+  def addMissingItem(c: SortedMap[String, Int],
+                     fb: FeatureBuilder[_]): Unit = missingValueOpt match {
+    case Some(missingValueToken) =>
+      val v = c.get(missingValueToken).get // manually added so will exist
+      fb.skip(v)
+      fb.add(name + '_' + missingValueToken, 1.0)
+      fb.skip(math.max(0, c.size - v - 1))
+    case _ => fb.skip(c.size)
+  }
+
   private def present(reduction: Set[String]): SortedMap[String, Int] = {
     val b = SortedMap.newBuilder[String, Int]
     var i = 0
-    val array = reduction.toArray
+    val array = missingValueOpt match {
+      case Some(missingValueToken) => reduction.toArray :+ missingValueToken
+      case None => reduction.toArray
+    }
     java.util.Arrays.sort(array, Ordering[String])
     while (i < array.length) {
       b += array(i) -> i
@@ -77,15 +103,19 @@ private abstract class BaseHotEncoder[A](name: String)
     }
     b.result()
   }
+
   override val aggregator: Aggregator[A, Set[String], SortedMap[String, Int]] =
     Aggregators.from[A](prepare).to(present)
+
   override def featureDimension(c: SortedMap[String, Int]): Int = c.size
+
   override def featureNames(c: SortedMap[String, Int]): Seq[String] = {
     c.map(name + '_' + _._1)(scala.collection.breakOut)
   }
 
   override def encodeAggregator(c: SortedMap[String, Int]): String =
     c.map(e => "label:" + URLEncoder.encode(e._1, "UTF-8")).mkString(",")
+
   override def decodeAggregator(s: String): SortedMap[String, Int] = {
     val a = s.split(",").filter(_.nonEmpty)
     var i = 0

--- a/core/src/main/scala/com/spotify/featran/transformers/OneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/OneHotEncoder.scala
@@ -77,7 +77,7 @@ object MissingValue {
 private abstract class BaseHotEncoder[A](name: String, encodeMissingValue: Boolean = false)
   extends Transformer[A, Set[String], SortedMap[String, Int]](name) {
 
-  private val missingValueToken = MissingValue.missingValueToken
+  val missingValueToken = MissingValue.missingValueToken
 
   def prepare(a: A): Set[String]
 

--- a/core/src/main/scala/com/spotify/featran/transformers/PositionEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/PositionEncoder.scala
@@ -39,7 +39,7 @@ object PositionEncoder {
     new PositionEncoder(name)
 }
 
-private class PositionEncoder(name: String) extends BaseHotEncoder[String](name) {
+private class PositionEncoder(name: String) extends BaseHotEncoder[String](name, false) {
   override def prepare(a: String): Set[String] = Set(a)
   override def featureDimension(c: SortedMap[String, Int]): Int = 1
   override def featureNames(c: SortedMap[String, Int]): Seq[String] = Seq(name)

--- a/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
@@ -26,40 +26,61 @@ import scala.collection.SortedMap
 import scala.util.Random
 
 /**
- * Transform a collection of categorical features to binary columns, with at most a single
- * one-value. Only the top N items are tracked.
- *
- * The list of top N is estimated with Algebird's SketchMap data structure. With probability
- * at least `1 - delta`, this estimate is within `eps * N` of the true frequency (i.e.,
- * `true frequency <= estimate <= true frequency + eps * N`), where N is the total size of the
- * input collection.
- *
- * Missing values are transformed to zero vectors.
- */
+  * Transform a collection of categorical features to binary columns, with at most a single
+  * one-value. Only the top N items are tracked.
+  *
+  * The list of top N is estimated with Algebird's SketchMap data structure. With probability
+  * at least `1 - delta`, this estimate is within `eps * N` of the true frequency (i.e.,
+  * `true frequency <= estimate <= true frequency + eps * N`), where N is the total size of the
+  * input collection.
+  *
+  * Missing values are either transformed to zero vectors or encoded as a missing value.
+  */
 object TopNOneHotEncoder {
-  /**
-   * Create a new [[TopNOneHotEncoder]] instance.
-   *
-   * @param n     number of items to keep track of
-   * @param eps   one-sided error bound on the error of each point query, i.e. frequency estimate
-   * @param delta a bound on the probability that a query estimate does not lie within some small
-   *              interval (an interval that depends on `eps`) around the truth.
-   * @param seed  a seed to initialize the random number generator used to create the pairwise
-   *              independent hash functions.
-   */
+/**
+  * Create a new [[TopNOneHotEncoder]] instance.
+  *
+  * @param n               number of items to keep track of
+  * @param eps             one-sided error bound on the error of each point query, i.e.
+  *                        frequency estimate
+  * @param delta           a bound on the probability that a query estimate does not lie within
+  *                        some small interval (an interval that depends on `eps`) around the
+  *                        truth.
+  * @param seed            a seed to initialize the random number generator used to create
+  *                        the pairwise independent hash functions.
+  * @param missingValueOpt optional name to encode items outside of the top n set.
+  */
   def apply(name: String, n: Int,
             eps: Double = 0.001,
             delta: Double = 0.001,
-            seed: Int = Random.nextInt)
+            seed: Int = Random.nextInt,
+            missingValueOpt: Option[String] = None)
   : Transformer[String, SketchMap[String, Long], SortedMap[String, Int]] =
-    new TopNOneHotEncoder(name, n, eps, delta, seed)
+    new TopNOneHotEncoder(name, n, eps, delta, seed, missingValueOpt)
+
+  def apply(name: String, n: Int,
+            eps: Double,
+            delta: Double,
+            seed: Int,
+            missingValue: String)
+  : Transformer[String, SketchMap[String, Long], SortedMap[String, Int]] =
+    new TopNOneHotEncoder(name, n, eps, delta, seed, Some(missingValue))
+
+  // extra apply for java compatibility
+  def apply(name: String, n: Int,
+            eps: Double,
+            delta: Double,
+            seed: Int)
+  : Transformer[String, SketchMap[String, Long], SortedMap[String, Int]] =
+    new TopNOneHotEncoder(name, n, eps, delta, seed, None)
 }
 
 private class TopNOneHotEncoder(name: String,
                                 val n: Int,
                                 val eps: Double,
                                 val delta: Double,
-                                val seed: Int)
+                                val seed: Int,
+                                val missingValueOpt: Option[String])
   extends Transformer[String, SketchMap[String, Long], SortedMap[String, Int]](name) {
 
   private val sketchMapParams =
@@ -71,15 +92,30 @@ private class TopNOneHotEncoder(name: String,
       .composePrepare[String]((_, 1L))
       .andThenPresent { sm =>
         val b = SortedMap.newBuilder[String, Int]
-        sm.heavyHitterKeys.sorted.iterator.zipWithIndex.foreach { case (k, r) =>
+        val topItems = missingValueOpt match {
+          case Some(missingValueToken) => sm.heavyHitterKeys :+ missingValueToken
+          case _ => sm.heavyHitterKeys
+        }
+        topItems.sorted.iterator.zipWithIndex.foreach { case (k, r) =>
           b += k -> r
         }
         b.result()
       }
 
   override def featureDimension(c: SortedMap[String, Int]): Int = c.size
+
   override def featureNames(c: SortedMap[String, Int]): Seq[String] =
     c.map(name + '_' + _._1)(scala.collection.breakOut)
+
+  def addNonTopItem(c: SortedMap[String, Int],
+                    fb: FeatureBuilder[_]): Unit = missingValueOpt match {
+    case Some(missingValueToken) =>
+      val v = c.get(missingValueToken).get // manually added so will exist
+      fb.skip(v)
+      fb.add(name + '_' + missingValueToken, 1.0)
+      fb.skip(math.max(0, c.size - v - 1))
+    case _ => fb.skip(c.size)
+  }
 
   override def buildFeatures(a: Option[String],
                              c: SortedMap[String, Int],
@@ -90,14 +126,15 @@ private class TopNOneHotEncoder(name: String,
         fb.add(name + '_' + k, 1.0)
         fb.skip(math.max(0, c.size - v - 1))
       case None =>
-        fb.skip(c.size)
+        addNonTopItem(c, fb)
         fb.reject(this, FeatureRejection.Unseen(Set(k)))
     }
-    case None => fb.skip(c.size)
+    case None => addNonTopItem(c, fb)
   }
 
   override def encodeAggregator(c: SortedMap[String, Int]): String =
     c.map(e => "label:" + URLEncoder.encode(e._1, "UTF-8")).mkString(",")
+
   override def decodeAggregator(s: String): SortedMap[String, Int] = {
     val a = s.split(",").filter(_.nonEmpty)
     var i = 0
@@ -108,10 +145,12 @@ private class TopNOneHotEncoder(name: String,
     }
     b.result()
   }
+
   override def params: Map[String, String] = Map(
     "n" -> n.toString,
     "eps" -> eps.toString,
     "delta" -> delta.toString,
-    "seed" -> seed.toString)
+    "seed" -> seed.toString,
+    "missingValueOpt" -> missingValueOpt.toString)
 
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
@@ -34,22 +34,20 @@ import scala.util.Random
  * `true frequency <= estimate <= true frequency + eps * N`), where N is the total size of the
  * input collection.
  *
- * Missing values are either transformed to zero vectors or encoded as __unknown__.
+ * Missing values are either transformed to zero vectors or encoded as `__unknown__`.
  */
 object TopNOneHotEncoder {
   /**
    * Create a new [[TopNOneHotEncoder]] instance.
    *
-   * @param n                  number of items to keep track of
-   * @param eps                one-sided error bound on the error of each point query, i.e.
-   *                           frequency estimate
-   * @param delta              a bound on the probability that a query estimate does not lie within
-   *                           some small interval (an interval that depends on `eps`) around the
-   *                           truth.
-   * @param seed               a seed to initialize the random number generator used to create
-   *                           the pairwise independent hash functions.
-   * @param encodeMissingValue boolean to indicate to encode items outside of the top n set
-   *                           as __unknown__.
+   * @param n number of items to keep track of
+   * @param eps one-sided error bound on the error of each point query, i.e. frequency estimate
+   * @param delta a bound on the probability that a query estimate does not lie within some small
+   *              interval (an interval that depends on `eps`) around the truth
+   * @param seed a seed to initialize the random number generator used to create the pairwise
+   *             independent hash functions
+   * @param encodeMissingValue whether to indicate to encode items outside of the top n set as
+   *                           `__unknown__`
    */
   def apply(name: String, n: Int,
             eps: Double = 0.001,
@@ -58,14 +56,6 @@ object TopNOneHotEncoder {
             encodeMissingValue: Boolean = false)
   : Transformer[String, SketchMap[String, Long], SortedMap[String, Int]] =
     new TopNOneHotEncoder(name, n, eps, delta, seed, encodeMissingValue)
-
-  /** Extra definition for java compatibility. */
-  def apply(name: String, n: Int,
-            eps: Double,
-            delta: Double,
-            seed: Int)
-  : Transformer[String, SketchMap[String, Long], SortedMap[String, Int]] =
-    new TopNOneHotEncoder(name, n, eps, delta, seed, false)
 }
 
 private class TopNOneHotEncoder(name: String,
@@ -73,10 +63,10 @@ private class TopNOneHotEncoder(name: String,
                                 val eps: Double,
                                 val delta: Double,
                                 val seed: Int,
-                                val encodeMissingValue: Boolean = false)
+                                val encodeMissingValue: Boolean)
   extends Transformer[String, SketchMap[String, Long], SortedMap[String, Int]](name) {
 
-  private val missingValueToken = MissingValue.missingValueToken
+  import MissingValue.missingValueToken
 
   private val sketchMapParams =
     SketchMapParams[String](seed, eps, delta, n)(_.getBytes)
@@ -87,11 +77,7 @@ private class TopNOneHotEncoder(name: String,
       .composePrepare[String]((_, 1L))
       .andThenPresent { sm =>
         val b = SortedMap.newBuilder[String, Int]
-        val topItems = encodeMissingValue match {
-          case true => sm.heavyHitterKeys :+ missingValueToken
-          case _ => sm.heavyHitterKeys
-        }
-        topItems.sorted.iterator.zipWithIndex.foreach { case (k, r) =>
+        sm.heavyHitterKeys.sorted.iterator.zipWithIndex.foreach { case (k, r) =>
           b += k -> r
         }
         b.result()
@@ -99,17 +85,16 @@ private class TopNOneHotEncoder(name: String,
 
   override def featureDimension(c: SortedMap[String, Int]): Int = c.size
 
-  override def featureNames(c: SortedMap[String, Int]): Seq[String] =
-    c.map(name + '_' + _._1)(scala.collection.breakOut)
+  override def featureNames(c: SortedMap[String, Int]): Seq[String] = {
+    val names = c.map(name + '_' + _._1)(scala.collection.breakOut)
+    if (encodeMissingValue) names :+ (name + '_' + missingValueToken) else names
+  }
 
-  def addNonTopItem(c: SortedMap[String, Int],
-                    fb: FeatureBuilder[_]): Unit = encodeMissingValue match {
-    case true =>
-      val v = c.get(missingValueToken).get // manually added so will exist
-      fb.skip(v)
+  def addNonTopItem(c: SortedMap[String, Int], fb: FeatureBuilder[_]): Unit = {
+    fb.skip(c.size)
+    if (encodeMissingValue) {
       fb.add(name + '_' + missingValueToken, 1.0)
-      fb.skip(math.max(0, c.size - v - 1))
-    case _ => fb.skip(c.size)
+    }
   }
 
   override def buildFeatures(a: Option[String],
@@ -120,6 +105,7 @@ private class TopNOneHotEncoder(name: String,
         fb.skip(v)
         fb.add(name + '_' + k, 1.0)
         fb.skip(math.max(0, c.size - v - 1))
+        if (encodeMissingValue) fb.skip()
       case None =>
         addNonTopItem(c, fb)
         fb.reject(this, FeatureRejection.Unseen(Set(k)))
@@ -129,7 +115,6 @@ private class TopNOneHotEncoder(name: String,
 
   override def encodeAggregator(c: SortedMap[String, Int]): String =
     c.map(e => "label:" + URLEncoder.encode(e._1, "UTF-8")).mkString(",")
-
   override def decodeAggregator(s: String): SortedMap[String, Int] = {
     val a = s.split(",").filter(_.nonEmpty)
     var i = 0
@@ -140,12 +125,11 @@ private class TopNOneHotEncoder(name: String,
     }
     b.result()
   }
-
   override def params: Map[String, String] = Map(
     "n" -> n.toString,
     "eps" -> eps.toString,
     "delta" -> delta.toString,
     "seed" -> seed.toString,
-    "missingValueOpt" -> encodeMissingValue.toString)
+    "encodeMissingValue" -> encodeMissingValue.toString)
 
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
@@ -26,53 +26,46 @@ import scala.collection.SortedMap
 import scala.util.Random
 
 /**
-  * Transform a collection of categorical features to binary columns, with at most a single
-  * one-value. Only the top N items are tracked.
-  *
-  * The list of top N is estimated with Algebird's SketchMap data structure. With probability
-  * at least `1 - delta`, this estimate is within `eps * N` of the true frequency (i.e.,
-  * `true frequency <= estimate <= true frequency + eps * N`), where N is the total size of the
-  * input collection.
-  *
-  * Missing values are either transformed to zero vectors or encoded as a missing value.
-  */
-object TopNOneHotEncoder {
-/**
- * Create a new [[TopNOneHotEncoder]] instance.
+ * Transform a collection of categorical features to binary columns, with at most a single
+ * one-value. Only the top N items are tracked.
  *
- * @param n               number of items to keep track of
- * @param eps             one-sided error bound on the error of each point query, i.e.
- *                        frequency estimate
- * @param delta           a bound on the probability that a query estimate does not lie within
- *                        some small interval (an interval that depends on `eps`) around the
- *                        truth.
- * @param seed            a seed to initialize the random number generator used to create
- *                        the pairwise independent hash functions.
- * @param missingValueOpt optional name to encode items outside of the top n set.
+ * The list of top N is estimated with Algebird's SketchMap data structure. With probability
+ * at least `1 - delta`, this estimate is within `eps * N` of the true frequency (i.e.,
+ * `true frequency <= estimate <= true frequency + eps * N`), where N is the total size of the
+ * input collection.
+ *
+ * Missing values are either transformed to zero vectors or encoded as __unknown__.
  */
+object TopNOneHotEncoder {
+  /**
+   * Create a new [[TopNOneHotEncoder]] instance.
+   *
+   * @param n                  number of items to keep track of
+   * @param eps                one-sided error bound on the error of each point query, i.e.
+   *                           frequency estimate
+   * @param delta              a bound on the probability that a query estimate does not lie within
+   *                           some small interval (an interval that depends on `eps`) around the
+   *                           truth.
+   * @param seed               a seed to initialize the random number generator used to create
+   *                           the pairwise independent hash functions.
+   * @param encodeMissingValue boolean to indicate to encode items outside of the top n set
+   *                           as __unknown__.
+   */
   def apply(name: String, n: Int,
             eps: Double = 0.001,
             delta: Double = 0.001,
             seed: Int = Random.nextInt,
-            missingValueOpt: Option[String] = None)
+            encodeMissingValue: Boolean = false)
   : Transformer[String, SketchMap[String, Long], SortedMap[String, Int]] =
-    new TopNOneHotEncoder(name, n, eps, delta, seed, missingValueOpt)
+    new TopNOneHotEncoder(name, n, eps, delta, seed, encodeMissingValue)
 
-  def apply(name: String, n: Int,
-            eps: Double,
-            delta: Double,
-            seed: Int,
-            missingValue: String)
-  : Transformer[String, SketchMap[String, Long], SortedMap[String, Int]] =
-    new TopNOneHotEncoder(name, n, eps, delta, seed, Some(missingValue))
-
-  // extra apply for java compatibility
+  /** Extra definition for java compatibility. */
   def apply(name: String, n: Int,
             eps: Double,
             delta: Double,
             seed: Int)
   : Transformer[String, SketchMap[String, Long], SortedMap[String, Int]] =
-    new TopNOneHotEncoder(name, n, eps, delta, seed, None)
+    new TopNOneHotEncoder(name, n, eps, delta, seed, false)
 }
 
 private class TopNOneHotEncoder(name: String,
@@ -80,8 +73,10 @@ private class TopNOneHotEncoder(name: String,
                                 val eps: Double,
                                 val delta: Double,
                                 val seed: Int,
-                                val missingValueOpt: Option[String])
+                                val encodeMissingValue: Boolean = false)
   extends Transformer[String, SketchMap[String, Long], SortedMap[String, Int]](name) {
+
+  val missingValueToken = "__unknown__"
 
   private val sketchMapParams =
     SketchMapParams[String](seed, eps, delta, n)(_.getBytes)
@@ -92,8 +87,8 @@ private class TopNOneHotEncoder(name: String,
       .composePrepare[String]((_, 1L))
       .andThenPresent { sm =>
         val b = SortedMap.newBuilder[String, Int]
-        val topItems = missingValueOpt match {
-          case Some(missingValueToken) => sm.heavyHitterKeys :+ missingValueToken
+        val topItems = encodeMissingValue match {
+          case true => sm.heavyHitterKeys :+ missingValueToken
           case _ => sm.heavyHitterKeys
         }
         topItems.sorted.iterator.zipWithIndex.foreach { case (k, r) =>
@@ -108,8 +103,8 @@ private class TopNOneHotEncoder(name: String,
     c.map(name + '_' + _._1)(scala.collection.breakOut)
 
   def addNonTopItem(c: SortedMap[String, Int],
-                    fb: FeatureBuilder[_]): Unit = missingValueOpt match {
-    case Some(missingValueToken) =>
+                    fb: FeatureBuilder[_]): Unit = encodeMissingValue match {
+    case true =>
       val v = c.get(missingValueToken).get // manually added so will exist
       fb.skip(v)
       fb.add(name + '_' + missingValueToken, 1.0)
@@ -151,6 +146,6 @@ private class TopNOneHotEncoder(name: String,
     "eps" -> eps.toString,
     "delta" -> delta.toString,
     "seed" -> seed.toString,
-    "missingValueOpt" -> missingValueOpt.toString)
+    "missingValueOpt" -> encodeMissingValue.toString)
 
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
@@ -76,7 +76,7 @@ private class TopNOneHotEncoder(name: String,
                                 val encodeMissingValue: Boolean = false)
   extends Transformer[String, SketchMap[String, Long], SortedMap[String, Int]](name) {
 
-  val missingValueToken = "__unknown__"
+  private val missingValueToken = MissingValue.missingValueToken
 
   private val sketchMapParams =
     SketchMapParams[String](seed, eps, delta, n)(_.getBytes)

--- a/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
@@ -38,18 +38,18 @@ import scala.util.Random
   */
 object TopNOneHotEncoder {
 /**
-  * Create a new [[TopNOneHotEncoder]] instance.
-  *
-  * @param n               number of items to keep track of
-  * @param eps             one-sided error bound on the error of each point query, i.e.
-  *                        frequency estimate
-  * @param delta           a bound on the probability that a query estimate does not lie within
-  *                        some small interval (an interval that depends on `eps`) around the
-  *                        truth.
-  * @param seed            a seed to initialize the random number generator used to create
-  *                        the pairwise independent hash functions.
-  * @param missingValueOpt optional name to encode items outside of the top n set.
-  */
+ * Create a new [[TopNOneHotEncoder]] instance.
+ *
+ * @param n               number of items to keep track of
+ * @param eps             one-sided error bound on the error of each point query, i.e.
+ *                        frequency estimate
+ * @param delta           a bound on the probability that a query estimate does not lie within
+ *                        some small interval (an interval that depends on `eps`) around the
+ *                        truth.
+ * @param seed            a seed to initialize the random number generator used to create
+ *                        the pairwise independent hash functions.
+ * @param missingValueOpt optional name to encode items outside of the top n set.
+ */
   def apply(name: String, n: Int,
             eps: Double = 0.001,
             delta: Double = 0.001,

--- a/core/src/test/scala/com/spotify/featran/transformers/NHotEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/NHotEncoderSpec.scala
@@ -35,21 +35,18 @@ object NHotEncoderSpec extends TransformerProp("NHotEncoder") {
   }
 
   property("encodeMissingValue") = Prop.forAll { xs: List[List[String]] =>
-    val missingValueToken = MissingValue.missingValueToken
-    val cats = (xs.flatten :+ missingValueToken).distinct.sorted
+    import MissingValue.missingValueToken
+    val cats = xs.flatten.distinct.sorted :+ missingValueToken
     val names = cats.map("n_hot_" + _)
     val missing = cats.map(c => if (c == missingValueToken) 1.0 else 0.0)
-    val expected = xs.map(s => {
-      s.size match {
-        case 0 => missing
-        case _ => cats.map(c => if (s.contains(c)) 1.0 else 0.0)
-      }
-    })
-    val partialMiss = expected(0).zip(missing).map { case (a, b) => a + b }
+    val expected = xs.map { s =>
+      if (s.isEmpty) missing else cats.map(c => if (s.contains(c)) 1.0 else 0.0)
+    }
+    val partialMiss = expected.head.zip(missing).map { case (a, b) => a + b }
 
     // unseen or partially unseen labels
-    val oob = List((List("s1", "s2"), missing), ((List("s1", "s2") ++ xs(0), partialMiss)))
-    test(NHotEncoder("n_hot", true), xs, names, expected, missing, oob)
+    val oob = List((List("s1", "s2"), missing), (List("s1", "s2") ++ xs.head, partialMiss))
+    test(NHotEncoder("n_hot", encodeMissingValue = true), xs, names, expected, missing, oob)
   }
 
 }

--- a/core/src/test/scala/com/spotify/featran/transformers/NHotEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/NHotEncoderSpec.scala
@@ -35,7 +35,7 @@ object NHotEncoderSpec extends TransformerProp("NHotEncoder") {
   }
 
   property("missingValueOpt") = Prop.forAll { xs: List[List[String]] =>
-    val missingValueToken = "missingToken"
+    val missingValueToken = MissingValue.missingValueToken
     val cats = (xs.flatten :+ missingValueToken).distinct.sorted
     val names = cats.map("n_hot_" + _)
     val missing = cats.map(c => if (c == missingValueToken) 1.0 else 0.0)
@@ -49,7 +49,7 @@ object NHotEncoderSpec extends TransformerProp("NHotEncoder") {
 
     // unseen or partially unseen labels
     val oob = List((List("s1", "s2"), missing), ((List("s1", "s2") ++ xs(0), partialMiss)))
-    test(NHotEncoder("n_hot", missingValueToken), xs, names, expected, missing, oob)
+    test(NHotEncoder("n_hot", true), xs, names, expected, missing, oob)
   }
 
 }

--- a/core/src/test/scala/com/spotify/featran/transformers/NHotEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/NHotEncoderSpec.scala
@@ -34,7 +34,7 @@ object NHotEncoderSpec extends TransformerProp("NHotEncoder") {
     test(NHotEncoder("n_hot"), xs, names, expected, missing, oob)
   }
 
-  property("missingValueOpt") = Prop.forAll { xs: List[List[String]] =>
+  property("encodeMissingValue") = Prop.forAll { xs: List[List[String]] =>
     val missingValueToken = MissingValue.missingValueToken
     val cats = (xs.flatten :+ missingValueToken).distinct.sorted
     val names = cats.map("n_hot_" + _)

--- a/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
@@ -40,7 +40,7 @@ object NHotWeightedEncoderSpec extends TransformerProp("NHotWeightedEncoder") {
   }
 
   property("missingValueOpt") = Prop.forAll { xs: List[List[WeightedLabel]] =>
-    val missingValueToken = "missingToken"
+    val missingValueToken = MissingValue.missingValueToken
     val cats = (xs.flatten.map(_.name) :+ missingValueToken).distinct.sorted
     val names = cats.map("n_hot_" + _)
     val expected = xs.map(s => cats.map(c => (0.0 +: s.filter(_.name == c).map(_.value)).sum))
@@ -48,7 +48,7 @@ object NHotWeightedEncoderSpec extends TransformerProp("NHotWeightedEncoder") {
 
     val oob = List((List(WeightedLabel("s1", 0.2), WeightedLabel("s2", 0.1)),
       missingBase.map(v => v * 0.3)))
-    test[Seq[WeightedLabel]](NHotWeightedEncoder("n_hot", missingValueToken),
+    test[Seq[WeightedLabel]](NHotWeightedEncoder("n_hot", true),
       xs, names, expected, missingBase, oob)
   }
 

--- a/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
@@ -33,22 +33,24 @@ object NHotWeightedEncoderSpec extends TransformerProp("NHotWeightedEncoder") {
   property("default") = Prop.forAll { xs: List[List[WeightedLabel]] =>
     val cats = xs.flatten.map(_.name).distinct.sorted
     val names = cats.map("n_hot_" + _)
-    val expected = xs.map(s => cats.map(c => (0.0 +: s.filter(_.name == c).map(_.value)).sum))
+    val expected = xs.map(s => cats.map(c => s.filter(_.name == c).map(_.value).sum))
     val missing = cats.map(_ => 0.0)
     val oob = List((List(WeightedLabel("s1", 0.2), WeightedLabel("s2", 0.1)), missing))
-    test[Seq[WeightedLabel]](NHotWeightedEncoder("n_hot"), xs, names, expected, missing, oob)
+    test(NHotWeightedEncoder("n_hot"), xs, names, expected, missing, oob)
   }
 
   property("encodeMissingValue") = Prop.forAll { xs: List[List[WeightedLabel]] =>
-    val missingValueToken = MissingValue.missingValueToken
-    val cats = (xs.flatten.map(_.name) :+ missingValueToken).distinct.sorted
+    import MissingValue.missingValueToken
+    val cats = xs.flatten.map(_.name).distinct.sorted :+ missingValueToken
     val names = cats.map("n_hot_" + _)
-    val expected = xs.map(s => cats.map(c => (0.0 +: s.filter(_.name == c).map(_.value)).sum))
+    val expected = xs.map(s => cats.map(c => s.filter(_.name == c).map(_.value).sum))
     val missingBase = cats.map(c => if (c == missingValueToken) 1.0 else 0.0)
 
-    val oob = List((List(WeightedLabel("s1", 0.2), WeightedLabel("s2", 0.1)),
+    val oob = List((
+      List(WeightedLabel("s1", 0.2), WeightedLabel("s2", 0.1)),
       missingBase.map(v => v * 0.3)))
-    test[Seq[WeightedLabel]](NHotWeightedEncoder("n_hot", true),
+    test(
+      NHotWeightedEncoder("n_hot", encodeMissingValue = true),
       xs, names, expected, missingBase, oob)
   }
 

--- a/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
@@ -39,7 +39,7 @@ object NHotWeightedEncoderSpec extends TransformerProp("NHotWeightedEncoder") {
     test[Seq[WeightedLabel]](NHotWeightedEncoder("n_hot"), xs, names, expected, missing, oob)
   }
 
-  property("missingValueOpt") = Prop.forAll { xs: List[List[WeightedLabel]] =>
+  property("encodeMissingValue") = Prop.forAll { xs: List[List[WeightedLabel]] =>
     val missingValueToken = MissingValue.missingValueToken
     val cats = (xs.flatten.map(_.name) :+ missingValueToken).distinct.sorted
     val names = cats.map("n_hot_" + _)

--- a/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/NHotWeightedEncoderSpec.scala
@@ -39,4 +39,17 @@ object NHotWeightedEncoderSpec extends TransformerProp("NHotWeightedEncoder") {
     test[Seq[WeightedLabel]](NHotWeightedEncoder("n_hot"), xs, names, expected, missing, oob)
   }
 
+  property("missingValueOpt") = Prop.forAll { xs: List[List[WeightedLabel]] =>
+    val missingValueToken = "missingToken"
+    val cats = (xs.flatten.map(_.name) :+ missingValueToken).distinct.sorted
+    val names = cats.map("n_hot_" + _)
+    val expected = xs.map(s => cats.map(c => (0.0 +: s.filter(_.name == c).map(_.value)).sum))
+    val missingBase = cats.map(c => if (c == missingValueToken) 1.0 else 0.0)
+
+    val oob = List((List(WeightedLabel("s1", 0.2), WeightedLabel("s2", 0.1)),
+      missingBase.map(v => v * 0.3)))
+    test[Seq[WeightedLabel]](NHotWeightedEncoder("n_hot", missingValueToken),
+      xs, names, expected, missingBase, oob)
+  }
+
 }

--- a/core/src/test/scala/com/spotify/featran/transformers/OneHotEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/OneHotEncoderSpec.scala
@@ -33,12 +33,12 @@ object OneHotEncoderSpec extends TransformerProp("OneHotEncoder") {
   }
 
   property("encodeMissingValue") = Prop.forAll { xs: List[String] =>
-    val missingValueToken = MissingValue.missingValueToken
-    val cats = (xs :+ missingValueToken).distinct.sorted
+    import MissingValue.missingValueToken
+    val cats = xs.distinct.sorted :+ missingValueToken
     val names = cats.map("one_hot_" + _)
     val expected = xs.map(s => cats.map(c => if (s == c) 1.0 else 0.0))
     val missing = cats.map(c => if (c == missingValueToken) 1.0 else 0.0)
     val oob = List(("s1", missing), ("s2", missing)) // unseen labels
-    test(OneHotEncoder("one_hot", true), xs, names, expected, missing, oob)
+    test(OneHotEncoder("one_hot", encodeMissingValue = true), xs, names, expected, missing, oob)
   }
 }

--- a/core/src/test/scala/com/spotify/featran/transformers/OneHotEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/OneHotEncoderSpec.scala
@@ -32,7 +32,7 @@ object OneHotEncoderSpec extends TransformerProp("OneHotEncoder") {
     test(OneHotEncoder("one_hot"), xs, names, expected, missing, oob)
   }
 
-  property("missingValueOpt") = Prop.forAll { xs: List[String] =>
+  property("encodeMissingValue") = Prop.forAll { xs: List[String] =>
     val missingValueToken = MissingValue.missingValueToken
     val cats = (xs :+ missingValueToken).distinct.sorted
     val names = cats.map("one_hot_" + _)

--- a/core/src/test/scala/com/spotify/featran/transformers/OneHotEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/OneHotEncoderSpec.scala
@@ -32,4 +32,13 @@ object OneHotEncoderSpec extends TransformerProp("OneHotEncoder") {
     test(OneHotEncoder("one_hot"), xs, names, expected, missing, oob)
   }
 
+  property("missingValueOpt") = Prop.forAll { xs: List[String] =>
+    val missingValueToken = "missingToken"
+    val cats = (xs :+ missingValueToken).distinct.sorted
+    val names = cats.map("one_hot_" + _)
+    val expected = xs.map(s => cats.map(c => if (s == c) 1.0 else 0.0))
+    val missing = cats.map(c => if (c == missingValueToken) 1.0 else 0.0)
+    val oob = List(("s1", missing), ("s2", missing)) // unseen labels
+    test(OneHotEncoder("one_hot", missingValueToken), xs, names, expected, missing, oob)
+  }
 }

--- a/core/src/test/scala/com/spotify/featran/transformers/OneHotEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/OneHotEncoderSpec.scala
@@ -33,12 +33,12 @@ object OneHotEncoderSpec extends TransformerProp("OneHotEncoder") {
   }
 
   property("missingValueOpt") = Prop.forAll { xs: List[String] =>
-    val missingValueToken = "missingToken"
+    val missingValueToken = MissingValue.missingValueToken
     val cats = (xs :+ missingValueToken).distinct.sorted
     val names = cats.map("one_hot_" + _)
     val expected = xs.map(s => cats.map(c => if (s == c) 1.0 else 0.0))
     val missing = cats.map(c => if (c == missingValueToken) 1.0 else 0.0)
     val oob = List(("s1", missing), ("s2", missing)) // unseen labels
-    test(OneHotEncoder("one_hot", missingValueToken), xs, names, expected, missing, oob)
+    test(OneHotEncoder("one_hot", true), xs, names, expected, missing, oob)
   }
 }

--- a/core/src/test/scala/com/spotify/featran/transformers/TopNOneHotEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/TopNOneHotEncoderSpec.scala
@@ -29,36 +29,34 @@ object TopNOneHotEncoderSpec extends TransformerProp("TopNOneHotEncoder") {
   }
   private val seed = 1
 
-  def getExpectedOutputVector(missingValueOpt: Option[String],
-                              s: String,
-                              cats: List[String]): Seq[Double] = {
-    val v: Seq[Double] = cats.map(c => if (s == c) 1.0 else 0.0)
-    missingValueOpt match {
-      case Some(missingValueToken) => {
-        v.sum match {
-          case nonZero if nonZero > 0 => v
-          case _ => cats.map(c => if (c == missingValueToken) 1.0 else 0.0)
-        }
-      }
-      case None => v
+  import MissingValue.missingValueToken
+
+  def getExpectedOutputVector(s: String, cats: List[String],
+                              encodeMissingValue: Boolean): Seq[Double] = {
+    val v = cats.map(c => if (s == c) 1.0 else 0.0)
+    if (encodeMissingValue && v.sum == 0.0) {
+      cats.map(c => if (c == missingValueToken) 1.0 else 0.0)
+    } else {
+      v
     }
   }
 
-  private def test(transformer: Transformer[String, _, _], xs: List[String],
-                   count: Int, eps: Double, delta: Double,
-                   missingValueOpt: Option[String]): Prop = {
-    val params = SketchMapParams[String](seed, eps, delta, count)(_.getBytes)
+  private def test(transformer: Transformer[String, _, _], xs: List[String]): Prop = {
+    val encoder = transformer.asInstanceOf[TopNOneHotEncoder]
+    val (n, eps, delta) = (encoder.n, encoder.eps, encoder.delta)
+    val encodeMissingValue = encoder.encodeMissingValue
+
+    val params = SketchMapParams[String](seed, eps, delta, n)(_.getBytes)
     val aggregator = SketchMap.aggregator[String, Long](params)
     val sm = xs.map(x => aggregator.prepare((x, 1L))).reduce(aggregator.monoid.plus)
-    val cats = missingValueOpt match {
-      case Some(missingValueToken) => (sm.heavyHitterKeys :+ missingValueToken).sorted
-      case _ => sm.heavyHitterKeys.sorted
-    }
+    val keys = sm.heavyHitterKeys.sorted
+    val cats = if (encodeMissingValue) keys :+ missingValueToken else keys
     val names = cats.map("tn1h_" + _)
-    val expected = xs.map(s => getExpectedOutputVector(missingValueOpt, s, cats))
-    val missing = missingValueOpt match {
-      case Some(missingValueToken) => cats.map(c => if (c == missingValueToken) 1.0 else 0.0)
-      case None => cats.map(_ => 0.0)
+    val expected = xs.map(s => getExpectedOutputVector(s, cats, encodeMissingValue))
+    val missing = if (encodeMissingValue) {
+      cats.map(c => if (c == missingValueToken) 1.0 else 0.0)
+    } else {
+      cats.map(_ => 0.0)
     }
     val oob = List(("s1", missing), ("s2", missing)) // unseen labels
     val rejected = xs.flatMap(x => if (cats.contains(x)) None else Some(missing))
@@ -67,25 +65,23 @@ object TopNOneHotEncoderSpec extends TransformerProp("TopNOneHotEncoder") {
   }
 
   property("default") = Prop.forAll { xs: List[String] =>
-    test(TopNOneHotEncoder("tn1h", 10, seed = 1), xs, 10, 0.001, 0.001, None)
+    test(TopNOneHotEncoder("tn1h", 10, seed = 1), xs)
   }
 
   property("count") = Prop.forAll { xs: List[String] =>
-    test(TopNOneHotEncoder("tn1h", 100, seed = 1), xs, 100, 0.001, 0.001, None)
+    test(TopNOneHotEncoder("tn1h", 100, seed = 1), xs)
   }
 
   property("eps") = Prop.forAll { xs: List[String] =>
-    test(TopNOneHotEncoder("tn1h", 10, eps = 0.01, seed = 1), xs, 10, 0.01, 0.001, None)
+    test(TopNOneHotEncoder("tn1h", 10, eps = 0.01, seed = 1), xs)
   }
 
   property("delta") = Prop.forAll { xs: List[String] =>
-    test(TopNOneHotEncoder("tn1h", 10, delta = 0.01, seed = 1), xs, 10, 0.001, 0.01, None)
+    test(TopNOneHotEncoder("tn1h", 10, delta = 0.01, seed = 1), xs)
   }
 
   property("encodeMissingValue") = Prop.forAll { xs: List[String] =>
-    val missingTokenOpt = Some(MissingValue.missingValueToken)
-    test(TopNOneHotEncoder("tn1h", 10, delta = 0.01, seed = 1, encodeMissingValue = true),
-      xs, 10, 0.001, 0.01, missingTokenOpt)
+    test(TopNOneHotEncoder("tn1h", 10, delta = 0.01, seed = 1, encodeMissingValue = true), xs)
   }
 
 }

--- a/core/src/test/scala/com/spotify/featran/transformers/TopNOneHotEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/TopNOneHotEncoderSpec.scala
@@ -83,8 +83,8 @@ object TopNOneHotEncoderSpec extends TransformerProp("TopNOneHotEncoder") {
   }
 
   property("missingValueOpt") = Prop.forAll { xs: List[String] =>
-    val missingTokenOpt = Some("missingToken")
-    test(TopNOneHotEncoder("tn1h", 10, delta = 0.01, seed = 1, missingValueOpt = missingTokenOpt),
+    val missingTokenOpt = Some(MissingValue.missingValueToken)
+    test(TopNOneHotEncoder("tn1h", 10, delta = 0.01, seed = 1, encodeMissingValue = true),
       xs, 10, 0.001, 0.01, missingTokenOpt)
   }
 

--- a/core/src/test/scala/com/spotify/featran/transformers/TopNOneHotEncoderSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/TopNOneHotEncoderSpec.scala
@@ -82,7 +82,7 @@ object TopNOneHotEncoderSpec extends TransformerProp("TopNOneHotEncoder") {
     test(TopNOneHotEncoder("tn1h", 10, delta = 0.01, seed = 1), xs, 10, 0.001, 0.01, None)
   }
 
-  property("missingValueOpt") = Prop.forAll { xs: List[String] =>
+  property("encodeMissingValue") = Prop.forAll { xs: List[String] =>
     val missingTokenOpt = Some(MissingValue.missingValueToken)
     test(TopNOneHotEncoder("tn1h", 10, delta = 0.01, seed = 1, encodeMissingValue = true),
       xs, 10, 0.001, 0.01, missingTokenOpt)

--- a/java/src/test/java/com/spotify/featran/java/JavaTestUtil.java
+++ b/java/src/test/java/com/spotify/featran/java/JavaTestUtil.java
@@ -29,19 +29,19 @@ public class JavaTestUtil {
 
   public static JFeatureSpec<Tuple2<String, Integer>> spec() {
     return JFeatureSpec.<Tuple2<String, Integer>>create()
-        .required(t -> t._1, OneHotEncoder.apply("one_hot"))
+        .required(t -> t._1, OneHotEncoder.apply("one_hot", false))
         .required(t -> t._2.doubleValue(), MinMaxScaler.apply("min_max", 0.0, 1.0));
   }
 
   public static JFeatureSpec<String> optionalSpec() {
     return JFeatureSpec.<String>create()
-        .optional(Optional::ofNullable, OneHotEncoder.apply("one_hot"));
+        .optional(Optional::ofNullable, OneHotEncoder.apply("one_hot", false));
   }
 
   public static JFeatureSpec<Tuple2<String, String>> crossSpec() {
     return JFeatureSpec.<Tuple2<String, String>>create()
-        .required(t -> t._1, OneHotEncoder.apply("one_hot_a"))
-        .required(t -> t._2, OneHotEncoder.apply("one_hot_b"))
+        .required(t -> t._1, OneHotEncoder.apply("one_hot_a", false))
+        .required(t -> t._2, OneHotEncoder.apply("one_hot_b", false))
         .cross("one_hot_a", "one_hot_b", (a, b) -> a * b);
   }
 

--- a/java/src/test/java/com/spotify/featran/java/examples/JavaExample.java
+++ b/java/src/test/java/com/spotify/featran/java/examples/JavaExample.java
@@ -55,7 +55,7 @@ public class JavaExample {
     // Start building a feature specification
     JFeatureSpec<Record> fs = JFeatureSpec.<Record>create()
         .required(r -> r.d, MinMaxScaler.apply("min-max", 0.0, 1.0))
-        .optional(r -> r.s, OneHotEncoder.apply("one-hot"));
+        .optional(r -> r.s, OneHotEncoder.apply("one-hot", false));
 
     // Extract features from List<Record>
     JFeatureExtractor<Record> f1 = fs.extract(records);


### PR DESCRIPTION
This PR provides users the option to encode missing or unseen items as a value in `OneHotEncoder`, `NHotEncoder`, `TopNOneHotEncoder` and `NHotWeightedEncoder`. In the current implementation missing/unseen items are transformed to the zero vector. The goal is to be able to model missing elements by explicitly assigning them a representation in the `{One, N}HotEncoding`. 

To assign, for example, `OneHotEncoder` with a default value of `missing-default` for unseen/missing items you'd specify the transformer as `OneHotEncoder("name", "missing-default")`. If no default value is provided then the encoder behaves as it normally would.

