### PR TITLE
increase dim by 1 for encodeMissingValue

### DIFF
--- a/core/src/main/scala/com/spotify/featran/transformers/OneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/OneHotEncoder.scala
@@ -98,7 +98,8 @@ private abstract class BaseHotEncoder[A](name: String, encodeMissingValue: Boole
 
   override val aggregator: Aggregator[A, Set[String], SortedMap[String, Int]] =
     Aggregators.from[A](prepare).to(present)
-  override def featureDimension(c: SortedMap[String, Int]): Int = c.size
+  override def featureDimension(c: SortedMap[String, Int]): Int =
+    if (encodeMissingValue) c.size + 1 else c.size
   override def featureNames(c: SortedMap[String, Int]): Seq[String] = {
     val names = c.map(name + '_' + _._1)(scala.collection.breakOut)
     if (encodeMissingValue) names :+ (name + '_' + missingValueToken) else names


### PR DESCRIPTION
When `encodeMissingValue` is true the dimension of the features will be the number of entries in the sorted map plus 1 for `__missing__`