### PR TITLE
Revert #102

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,9 +123,8 @@ lazy val core: Project = Project(
   moduleName := "featran-core",
   description := "Feature Transformers",
   libraryDependencies ++= Seq(
-    "com.twitter" %% "algebird-core" % algebirdVersion excludeAll ("org.typelevel" %% "algebra"),
+    "com.twitter" %% "algebird-core" % algebirdVersion,
     "org.scalanlp" %% "breeze" % breezeVersion,
-    "org.typelevel" %% "algebra" % "1.0.0",
     "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
     "org.scalatest" %% "scalatest" % scalatestVersion % "test",
     "org.apache.commons" % "commons-math3" % commonsMathVersion % "test"


### PR DESCRIPTION
After a little bit more digging around dependency resolution/conflicts ... I think it's wise to revert this change. The eviction `warn` that we get is only about a transitive dependency. If it was a direct one the story would be different.