### PR TITLE
treat empty input as a missing value

### DIFF
--- a/core/src/main/scala/com/spotify/featran/transformers/NHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/NHotEncoder.scala
@@ -46,6 +46,16 @@ private class NHotEncoder(name: String, encodeMissingValue: Boolean)
 
   import MissingValue.missingValueToken
 
+  def checkForMissingValue(fb: FeatureBuilder[_],
+                           unseen: MSet[String],
+                           keys: Seq[String]): Unit = {
+    if (unseen.isEmpty && !keys.isEmpty) {
+      fb.skip()
+    } else {
+      fb.add(name + '_' + missingValueToken, 1.0)
+    }
+  }
+
   override def prepare(a: Seq[String]): Set[String] = Set(a: _*)
   override def buildFeatures(a: Option[Seq[String]],
                              c: SortedMap[String, Int],
@@ -68,11 +78,7 @@ private class NHotEncoder(name: String, encodeMissingValue: Boolean)
       val gap = c.size - prev - 1
       if (gap > 0) fb.skip(gap)
       if (encodeMissingValue) {
-        if (unseen.isEmpty) {
-          fb.skip()
-        } else {
-          fb.add(name + '_' + missingValueToken, 1.0)
-        }
+        checkForMissingValue(fb, unseen, keys)
       }
       if (unseen.nonEmpty) {
         fb.reject(this, FeatureRejection.Unseen(unseen.toSet))

--- a/core/src/main/scala/com/spotify/featran/transformers/NHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/NHotEncoder.scala
@@ -46,10 +46,9 @@ private class NHotEncoder(name: String, encodeMissingValue: Boolean)
 
   import MissingValue.missingValueToken
 
-  def checkForMissingValue(fb: FeatureBuilder[_],
-                           unseen: MSet[String],
-                           keys: Seq[String]): Unit = {
-    if (unseen.isEmpty && !keys.isEmpty) {
+  def addMissingValue(fb: FeatureBuilder[_], unseen: MSet[String], keys: Seq[String]): Unit = {
+    if (unseen.isEmpty
+        && keys.nonEmpty) {
       fb.skip()
     } else {
       fb.add(name + '_' + missingValueToken, 1.0)
@@ -78,7 +77,7 @@ private class NHotEncoder(name: String, encodeMissingValue: Boolean)
       val gap = c.size - prev - 1
       if (gap > 0) fb.skip(gap)
       if (encodeMissingValue) {
-        checkForMissingValue(fb, unseen, keys)
+        addMissingValue(fb, unseen, keys)
       }
       if (unseen.nonEmpty) {
         fb.reject(this, FeatureRejection.Unseen(unseen.toSet))

--- a/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
@@ -55,6 +55,20 @@ private class NHotWeightedEncoder(name: String, encodeMissingValue: Boolean)
 
   import MissingValue.missingValueToken
 
+  def checkForMissingValue(fb: FeatureBuilder[_],
+                           unseen: MSet[String],
+                           keys: Seq[String],
+                           unseenWeight: Double): Unit = {
+    if (keys.isEmpty) {
+      fb.add(name + '_' + missingValueToken, 1.0)
+    }
+    else if (unseen.isEmpty) {
+      fb.skip()
+    } else {
+      fb.add(name + '_' + missingValueToken, unseenWeight)
+    }
+  }
+
   override def prepare(a: Seq[WeightedLabel]): Set[String] =
     Set(a.map(_.name): _*)
   override def buildFeatures(a: Option[Seq[WeightedLabel]],
@@ -83,11 +97,7 @@ private class NHotWeightedEncoder(name: String, encodeMissingValue: Boolean)
       val gap = c.size - prev - 1
       if (gap > 0) fb.skip(gap)
       if (encodeMissingValue) {
-        if (unseen.isEmpty) {
-          fb.skip()
-        } else {
-          fb.add(name + '_' + missingValueToken, unseenWeight)
-        }
+        checkForMissingValue(fb, unseen, keys, unseenWeight)
       }
       if (unseen.nonEmpty) {
         fb.reject(this, FeatureRejection.Unseen(unseen.toSet))

--- a/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
@@ -55,14 +55,13 @@ private class NHotWeightedEncoder(name: String, encodeMissingValue: Boolean)
 
   import MissingValue.missingValueToken
 
-  def checkForMissingValue(fb: FeatureBuilder[_],
-                           unseen: MSet[String],
-                           keys: Seq[String],
-                           unseenWeight: Double): Unit = {
+  def addMissingValue(fb: FeatureBuilder[_],
+                      unseen: MSet[String],
+                      keys: Seq[String],
+                      unseenWeight: Double): Unit = {
     if (keys.isEmpty) {
       fb.add(name + '_' + missingValueToken, 1.0)
-    }
-    else if (unseen.isEmpty) {
+    } else if (unseen.isEmpty) {
       fb.skip()
     } else {
       fb.add(name + '_' + missingValueToken, unseenWeight)
@@ -97,7 +96,7 @@ private class NHotWeightedEncoder(name: String, encodeMissingValue: Boolean)
       val gap = c.size - prev - 1
       if (gap > 0) fb.skip(gap)
       if (encodeMissingValue) {
-        checkForMissingValue(fb, unseen, keys, unseenWeight)
+        addMissingValue(fb, unseen, keys, unseenWeight)
       }
       if (unseen.nonEmpty) {
         fb.reject(this, FeatureRejection.Unseen(unseen.toSet))


### PR DESCRIPTION
Want to treat the case where `xs` is an empty sequence as a missing value. In this case `keys` would also be empty. 