### PR TITLE
Slhansen/return names

### DIFF
--- a/core/src/main/scala/com/spotify/featran/CrossingFeatureBuilder.scala
+++ b/core/src/main/scala/com/spotify/featran/CrossingFeatureBuilder.scala
@@ -150,6 +150,7 @@ private class CrossingFeatureBuilder[F] private (private val fb: FeatureBuilder[
   override def reject(transformer: Transformer[_, _, _], reason: FeatureRejection): Unit =
     fb.reject(transformer, reason)
   override def rejections: Map[String, FeatureRejection] = fb.rejections
+  override def names: Seq[String] = fb.names
 
   override def newBuilder: FeatureBuilder[F] = CrossingFeatureBuilder(fb, crossings)
 }

--- a/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
@@ -46,6 +46,8 @@ object FeatureRejection {
   private val _rejections: mutable.Map[String, FeatureRejection] =
     mutable.Map.empty
 
+  private val _names: mutable.ListBuffer[String] = mutable.ListBuffer.empty
+
   /**
    * Reject an input row.
    * @param transformer transformer rejecting the input
@@ -65,6 +67,22 @@ object FeatureRejection {
     val r = _rejections.toMap
     _rejections.clear()
     r
+  }
+
+  /**
+   * Add name of nonzero feature.
+   * @param name name of nonzero element
+   */
+  def addName(name: String): Unit = _names += name
+
+  /**
+   * Gather names of nonzero feature elements. This should be called only once per input row.
+   * @return
+   */
+  def names: Seq[String] = {
+    val n = _names.toSeq
+    _names.clear()
+    n
   }
 
   /**
@@ -168,6 +186,7 @@ object FeatureBuilder {
 
     override def add(name: String, value: Double): Unit = {
       underlying(offset) = FloatingPoint[T].fromDouble(value)
+      addName(name)
       offset += 1
     }
 
@@ -217,8 +236,10 @@ object FeatureBuilder {
 
     override def init(dimension: Int): Unit = underlying = cb()
 
-    override def add(name: String, value: Double): Unit =
+    override def add(name: String, value: Double): Unit = {
       underlying += FloatingPoint[T].fromDouble(value)
+      addName(name)
+    }
 
     override def skip(): Unit = underlying += FloatingPoint[T].fromDouble(0.0)
 
@@ -253,6 +274,7 @@ object FeatureBuilder {
     override def add(name: String, value: Double): Unit = {
       indices(i) = offset
       values(i) = FloatingPoint[T].fromDouble(value)
+      addName(name)
       i += 1
       offset += 1
       if (indices.length == i) {

--- a/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
@@ -151,6 +151,7 @@ object FeatureRejection {
       delegate.add(name, value)
     override def skip(): Unit = delegate.skip()
     override def result: U = g(delegate.result)
+    override def names: Seq[String] = delegate.names
 
     override def newBuilder: FeatureBuilder[U] = delegate.newBuilder.map(g)
   }

--- a/core/src/main/scala/com/spotify/featran/FeatureExtractor.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureExtractor.scala
@@ -97,12 +97,15 @@ class FeatureExtractor[M[_]: CollectionType, T] private[featran] (
       case (((o, a), c), spec) =>
         val cfb = CrossingFeatureBuilder(fb, spec.crossings)
         spec.featureValues(a, c, cfb)
-        FeatureResult(cfb.result, cfb.rejections, o)
+        FeatureResult(cfb.result, cfb.rejections, o, cfb.names)
     }
   }
 }
 
-case class FeatureResult[F, T](value: F, rejections: Map[String, FeatureRejection], original: T)
+case class FeatureResult[F, T](value: F,
+                               rejections: Map[String, FeatureRejection],
+                               original: T,
+                               names: Seq[String])
 
 object RecordExtractor {
   private class PipeIterator[T] extends Iterator[T] {

--- a/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
@@ -100,16 +100,17 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
   property("original") = Prop.forAll { xs: List[Record] =>
     val f = FeatureSpec.of[Record].required(_.d)(id).extract(xs)
     Prop.all(f.featureNames == Seq(Seq("id")),
-             f.featureResults[Seq[Double]] == xs.map(r => FeatureResult(Seq(r.d), Map.empty, r)))
+             f.featureResults[Seq[Double]] ==
+               xs.map(r => FeatureResult(Seq(r.d), Map.empty, r, Seq("id"))))
   }
 
   property("combine") = Prop.forAll { xs: List[Record] =>
     val f1 = FeatureSpec.of[Record].required(_.d)(id)
     val f2 = FeatureSpec.of[Record].required(_.d)(id2)
     val result = FeatureSpec.combine(f1, f2).extract(xs)
-    Prop.all(
-      result.featureNames == Seq(Seq("id", "id2")),
-      result.featureResults[Seq[Double]] == xs.map(r => FeatureResult(Seq(r.d, r.d), Map.empty, r)))
+    Prop.all(result.featureNames == Seq(Seq("id", "id2")),
+             result.featureResults[Seq[Double]] ==
+               xs.map(r => FeatureResult(Seq(r.d, r.d), Map.empty, r, Seq("id", "id2"))))
   }
 
   property("extra feature in settings") = Prop.forAll { xs: List[Record] =>
@@ -118,7 +119,8 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
     val settings = f1.extract(xs).featureSettings
     val f = f2.extractWithSettings(xs, settings)
     Prop.all(f.featureNames == Seq(Seq("id")),
-             f.featureResults[Seq[Double]] == xs.map(r => FeatureResult(Seq(r.d), Map.empty, r)))
+             f.featureResults[Seq[Double]] ==
+               xs.map(r => FeatureResult(Seq(r.d), Map.empty, r, Seq("id"))))
   }
 
   property("missing feature in settings") = Prop.forAll { xs: List[Record] =>
@@ -152,9 +154,9 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
           includeFeatures.contains(f.transformer.name)
         }
         .extract(xs)
-      Prop.all(
-        extracted.featureNames.head == Seq("id"),
-        extracted.featureResults[Seq[Double]] == xs.map(r => FeatureResult(Seq(r.d), Map.empty, r)))
+      Prop.all(extracted.featureNames.head == Seq("id"),
+               extracted.featureResults[Seq[Double]] ==
+                 xs.map(r => FeatureResult(Seq(r.d), Map.empty, r, List("id"))))
   }
 
   property("extract with partial settings") = Prop.forAll { xs: List[Record] =>


### PR DESCRIPTION
The purpose of this PR is to return the names (e.g. `one_hot_<token>`) of the non-zero elements when calling `featureResults`. We need this information in order to experiment with field aware factorization machines.