### PR TITLE
Add functions that uses Featran functions to map to a different raw feature type.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ val simulacrumVersion = "0.12.0"
 val sparkVersion = "2.3.0"
 val tensorflowVersion = "1.8.0"
 val xgBoostVersion = "0.72-20180627-1214081f"
+val shapelessDatatypeVersion = "0.1.6"
 
 val CompileTime = config("compile-time").hide
 
@@ -297,6 +298,7 @@ lazy val tensorflow: Project = project
     description := "Feature Transformers - TensorFlow",
     libraryDependencies ++= Seq(
       "org.tensorflow" % "proto" % tensorflowVersion,
+      "me.lyh" %% "shapeless-datatype-tensorflow" % shapelessDatatypeVersion,
       "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test"
     )
   )

--- a/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureSpec.scala
@@ -117,8 +117,8 @@ class FeatureSpec[T] private[featran] (private[featran] val features: Array[Feat
    * For an example of this see the tensorflow subproject where mapping between Scala and TFExample
    * can be done through this method.
    */
-  def convert[M[_], C, D](
-    input: M[T])(implicit fw: Converter[C, D], ct: ClassTag[C], dt: CollectionType[M]): M[C] = {
+  def convert[M[_], C](
+    input: M[T])(implicit fw: Converter[C], ct: ClassTag[C], dt: CollectionType[M]): M[C] = {
     import CollectionType.ops._
     val fns = ConvertFns(features.map(f => fw(f.transformer.name, f.typ, f.f)).toList)
     input.map { row =>

--- a/core/src/main/scala/com/spotify/featran/MultiFeatureSpec.scala
+++ b/core/src/main/scala/com/spotify/featran/MultiFeatureSpec.scala
@@ -57,8 +57,8 @@ class MultiFeatureSpec[T](private[featran] val mapping: Map[String, Int],
    * For an example of this see the tensorflow subproject where mapping between Scala and TFExample
    * can be done through this method.
    */
-  def convert[M[_], C, D](
-    input: M[T])(implicit fw: Converter[C, D], ct: ClassTag[C], dt: CollectionType[M]): M[C] = {
+  def convert[M[_], C](
+    input: M[T])(implicit fw: Converter[C], ct: ClassTag[C], dt: CollectionType[M]): M[C] = {
     import CollectionType.ops._
     val fns = ConvertFns(features.map(f => fw(f.transformer.name, f.typ, f.f)).toList)
     input.map { row =>

--- a/core/src/main/scala/com/spotify/featran/MultiFeatureSpec.scala
+++ b/core/src/main/scala/com/spotify/featran/MultiFeatureSpec.scala
@@ -17,7 +17,10 @@
 
 package com.spotify.featran
 
+import com.spotify.featran.transformers.Converter
+
 import scala.language.{higherKinds, implicitConversions}
+import scala.reflect.ClassTag
 
 /**
  * Companion object for [[MultiFeatureSpec]].
@@ -41,6 +44,12 @@ object MultiFeatureSpec {
 class MultiFeatureSpec[T](private[featran] val mapping: Map[String, Int],
                           private[featran] val features: Array[Feature[T, _, _, _]],
                           private val crossings: Crossings) {
+
+  def convert[M[_], C](input: M[T])
+    (implicit fw: Converter[C], ct: ClassTag[C], dt: CollectionType[M]): M[C] = {
+    import dt.Ops._
+    input.map{row => fw.convert(row, features.toList)}
+  }
 
   /**
    * Extract features from a input collection.

--- a/core/src/main/scala/com/spotify/featran/MultiFeatureSpec.scala
+++ b/core/src/main/scala/com/spotify/featran/MultiFeatureSpec.scala
@@ -17,10 +17,10 @@
 
 package com.spotify.featran
 
-import com.spotify.featran.transformers.Converter
+import com.spotify.featran.transformers.{ConvertFns, Converter, Settings}
+
 import scala.language.{higherKinds, implicitConversions}
 import scala.reflect.ClassTag
-import com.spotify.featran.transformers.Settings
 import scala.collection.breakOut
 
 /**
@@ -57,11 +57,12 @@ class MultiFeatureSpec[T](private[featran] val mapping: Map[String, Int],
    * For an example of this see the tensorflow subproject where mapping between Scala and TFExample
    * can be done through this method.
    */
-  def convert[M[_], C](
-    input: M[T])(implicit fw: Converter[C], ct: ClassTag[C], dt: CollectionType[M]): M[C] = {
+  def convert[M[_], C, D](
+    input: M[T])(implicit fw: Converter[C, D], ct: ClassTag[C], dt: CollectionType[M]): M[C] = {
     import CollectionType.ops._
+    val fns = ConvertFns(features.map(f => fw(f.transformer.name, f.typ, f.f)).toList)
     input.map { row =>
-      fw.convert(row, features.toList)
+      fw.convert(row, fns)
     }
   }
 

--- a/core/src/main/scala/com/spotify/featran/MultiFeatureSpec.scala
+++ b/core/src/main/scala/com/spotify/featran/MultiFeatureSpec.scala
@@ -46,14 +46,24 @@ class MultiFeatureSpec[T](private[featran] val mapping: Map[String, Int],
                           private[featran] val features: Array[Feature[T, _, _, _]],
                           private val crossings: Crossings) {
 
-  def convert[M[_], C](input: M[T])
-    (implicit fw: Converter[C], ct: ClassTag[C], dt: CollectionType[M]): M[C] = {
-    import CollectionType.ops._
-    input.map{row => fw.convert(row, features.toList)}
-  }
-
   private def multiFeatureSet: MultiFeatureSet[T] =
     new MultiFeatureSet[T](features, crossings, mapping)
+
+  /**
+   * Uses the functions provided in the Featran Spec to `map` the scala object into a new type
+   * given by C.  This function does not do the transformations internal to Featran but instead
+   * can be used as a mapper.
+   *
+   * For an example of this see the tensorflow subproject where mapping between Scala and TFExample
+   * can be done through this method.
+   */
+  def convert[M[_], C](
+    input: M[T])(implicit fw: Converter[C], ct: ClassTag[C], dt: CollectionType[M]): M[C] = {
+    import CollectionType.ops._
+    input.map { row =>
+      fw.convert(row, features.toList)
+    }
+  }
 
   /**
    * Extract features from a input collection.

--- a/core/src/main/scala/com/spotify/featran/transformers/Transformer.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/Transformer.scala
@@ -17,10 +17,21 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.FeatureBuilder
+import com.spotify.featran.{Feature, FeatureBuilder}
 import com.twitter.algebird.{Aggregator, Semigroup}
 
 import scala.language.higherKinds
+
+case class NamedFn[T, A](name: String, fn: T => A)
+
+trait Converter[C]{
+  def convert[T](row: T, feat: List[Feature[T, _, _, _]]): C
+}
+
+abstract class ConvertFunction[+C] {
+  import scala.reflect.runtime.universe._
+  def apply[A: TypeTag](name: String, a: A): C
+}
 
 // TODO: port more transformers from Spark
 // https://spark.apache.org/docs/2.1.0/ml-features.html
@@ -116,7 +127,6 @@ abstract class Transformer[-A, B, C](val name: String) extends Serializable {
              params,
              optFeatureNames(c),
              c.map(encodeAggregator))
-
 }
 
 case class Settings(cls: String,

--- a/core/src/main/scala/com/spotify/featran/transformers/Transformer.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/Transformer.scala
@@ -24,7 +24,7 @@ import scala.language.higherKinds
 
 case class NamedFn[T, A](name: String, fn: T => A)
 
-trait Converter[C]{
+trait Converter[C] {
   def convert[T](row: T, feat: List[Feature[T, _, _, _]]): C
 }
 

--- a/core/src/main/scala/com/spotify/featran/transformers/Transformer.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/Transformer.scala
@@ -17,20 +17,16 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{Feature, FeatureBuilder, JsonSerializable}
+import com.spotify.featran.{FeatureBuilder, JsonSerializable}
 import com.twitter.algebird.{Aggregator, Semigroup}
 
 import scala.language.higherKinds
 
-case class NamedFn[T, A](name: String, fn: T => A)
-
-trait Converter[C] {
-  def convert[T](row: T, feat: List[Feature[T, _, _, _]]): C
-}
-
-abstract class ConvertFunction[+C] {
+case class ConvertFns[T, C](fns: List[(T => C)]) extends Serializable
+trait Converter[C, D] extends Serializable {
   import scala.reflect.runtime.universe._
-  def apply[A: TypeTag](name: String, a: A): C
+  def apply[T, A](name: String, typ: Type, fn: T => Option[A]): T => D
+  def convert[T](row: T, fns: ConvertFns[T, D]): C
 }
 
 // TODO: port more transformers from Spark

--- a/core/src/main/scala/com/spotify/featran/transformers/Transformer.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/Transformer.scala
@@ -19,14 +19,16 @@ package com.spotify.featran.transformers
 
 import com.spotify.featran.{FeatureBuilder, JsonSerializable}
 import com.twitter.algebird.{Aggregator, Semigroup}
+import simulacrum.typeclass
 
 import scala.language.higherKinds
 
-case class ConvertFns[T, C](fns: List[(T => C)]) extends Serializable
-trait Converter[C, D] extends Serializable {
+case class ConvertFns[T, D](fns: List[(T => D)]) extends Serializable
+@typeclass trait Converter[C] extends Serializable {
+  type RT //Generic Type that is returned per feature
   import scala.reflect.runtime.universe._
-  def apply[T, A](name: String, typ: Type, fn: T => Option[A]): T => D
-  def convert[T](row: T, fns: ConvertFns[T, D]): C
+  def apply[T, A](name: String, typ: Type, fn: T => Option[A]): T => RT
+  def convert[T](row: T, fns: ConvertFns[T, RT]): C
 }
 
 // TODO: port more transformers from Spark

--- a/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
@@ -24,6 +24,8 @@ import com.spotify.featran.FeatureSpec
 import org.scalacheck.Prop.BooleanOperators
 import org.scalacheck._
 
+import scala.reflect.runtime.universe.TypeTag
+
 abstract class TransformerProp(name: String) extends Properties(name) {
 
   implicit def list[T](implicit arb: Arbitrary[T]): Arbitrary[List[T]] =
@@ -44,7 +46,7 @@ abstract class TransformerProp(name: String) extends Properties(name) {
     xs.map(_.map(d2e)) == ys.map(_.map(d2e))
 
   // scalastyle:off method.length
-  def test[T](t: Transformer[T, _, _],
+  def test[T: TypeTag](t: Transformer[T, _, _],
               input: List[T],
               names: Seq[String],
               expected: List[Seq[Double]],
@@ -104,7 +106,7 @@ abstract class TransformerProp(name: String) extends Properties(name) {
   }
   // scalastyle:on method.length
 
-  def testException[T](t: Transformer[T, _, _], input: List[T])(p: Throwable => Boolean): Prop =
+  def testException[T: TypeTag](t: Transformer[T, _, _], input: List[T])(p: Throwable => Boolean): Prop =
     try {
       FeatureSpec.of[T].required(identity)(t).extract(input).featureValues[Seq[Double]]
       false

--- a/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
@@ -47,12 +47,12 @@ abstract class TransformerProp(name: String) extends Properties(name) {
 
   // scalastyle:off method.length
   def test[T: TypeTag](t: Transformer[T, _, _],
-              input: List[T],
-              names: Seq[String],
-              expected: List[Seq[Double]],
-              missing: Seq[Double],
-              outOfBoundsElems: List[(T, Seq[Double])] = Nil,
-              rejected: List[Seq[Double]] = Nil): Prop = {
+                       input: List[T],
+                       names: Seq[String],
+                       expected: List[Seq[Double]],
+                       missing: Seq[Double],
+                       outOfBoundsElems: List[(T, Seq[Double])] = Nil,
+                       rejected: List[Seq[Double]] = Nil): Prop = {
     val fsRequired = FeatureSpec.of[T].required(identity)(t)
     val fsOptional = FeatureSpec.of[Option[T]].optional(identity)(t)
 
@@ -106,7 +106,8 @@ abstract class TransformerProp(name: String) extends Properties(name) {
   }
   // scalastyle:on method.length
 
-  def testException[T: TypeTag](t: Transformer[T, _, _], input: List[T])(p: Throwable => Boolean): Prop =
+  def testException[T: TypeTag](t: Transformer[T, _, _], input: List[T])(
+    p: Throwable => Boolean): Prop =
     try {
       FeatureSpec.of[T].required(identity)(t).extract(input).featureValues[Seq[Double]]
       false

--- a/java/src/main/java/com/spotify/featran/java/JFeatureSpec.java
+++ b/java/src/main/java/com/spotify/featran/java/JFeatureSpec.java
@@ -65,21 +65,19 @@ public class JFeatureSpec<T> {
    * Java wrapper for {@link FeatureSpec#required(Function1, Transformer)}.
    */
   public <A> JFeatureSpec<T> required(final SerializableFunction<T, A> f,
-                                      final Transformer<A, ?, ?> t,
-                                      final Class<A> typeParameterClass) {
+                                      final Transformer<A, ?, ?> t) {
     Function1<T, A> g = JavaOps.requiredFn(f);
-    return wrap(self.required(g, t, JavaOps.typeTag(typeParameterClass)));
+    return wrap(self.required(g, t, null));
   }
 
   /**
    * Java wrapper for {@link FeatureSpec#optional(Function1, Transformer)}.
    */
   public <A> JFeatureSpec<T> optional(final SerializableFunction<T, Optional<A>> f,
-                                      final Transformer<A, ?, ?> t,
-                                      final Class<A> typeParameterClass) {
+                                      final Transformer<A, ?, ?> t) {
     Function1<T, Option<A>> g = JavaOps.optionalFn(f);
     Option<A> o = Option.empty();
-    return wrap(self.optional(g, o, t, JavaOps.typeTag(typeParameterClass)));
+    return wrap(self.optional(g, o, t, null));
   }
 
   /**
@@ -87,11 +85,10 @@ public class JFeatureSpec<T> {
    */
   public <A> JFeatureSpec<T> optional(final SerializableFunction<T, Optional<A>> f,
                                       final A defaultValue,
-                                      final Transformer<A, ?, ?> t,
-                                      final Class<A> typeParameterClass) {
+                                      final Transformer<A, ?, ?> t) {
     Function1<T, Option<A>> g = JavaOps.optionalFn(f);
     Option<A> o = Option.apply(defaultValue);
-    return wrap(self.optional(g, o, t, JavaOps.typeTag(typeParameterClass)));
+    return wrap(self.optional(g, o, t, null));
   }
 
   /**

--- a/java/src/main/java/com/spotify/featran/java/JFeatureSpec.java
+++ b/java/src/main/java/com/spotify/featran/java/JFeatureSpec.java
@@ -65,19 +65,21 @@ public class JFeatureSpec<T> {
    * Java wrapper for {@link FeatureSpec#required(Function1, Transformer)}.
    */
   public <A> JFeatureSpec<T> required(final SerializableFunction<T, A> f,
-                                      final Transformer<A, ?, ?> t) {
+                                      final Transformer<A, ?, ?> t,
+                                      final Class<A> typeParameterClass) {
     Function1<T, A> g = JavaOps.requiredFn(f);
-    return wrap(self.required(g, t));
+    return wrap(self.required(g, t, JavaOps.typeTag(typeParameterClass)));
   }
 
   /**
    * Java wrapper for {@link FeatureSpec#optional(Function1, Transformer)}.
    */
   public <A> JFeatureSpec<T> optional(final SerializableFunction<T, Optional<A>> f,
-                                      final Transformer<A, ?, ?> t) {
+                                      final Transformer<A, ?, ?> t,
+                                      final Class<A> typeParameterClass) {
     Function1<T, Option<A>> g = JavaOps.optionalFn(f);
     Option<A> o = Option.empty();
-    return wrap(self.optional(g, o, t));
+    return wrap(self.optional(g, o, t, JavaOps.typeTag(typeParameterClass)));
   }
 
   /**
@@ -85,10 +87,11 @@ public class JFeatureSpec<T> {
    */
   public <A> JFeatureSpec<T> optional(final SerializableFunction<T, Optional<A>> f,
                                       final A defaultValue,
-                                      final Transformer<A, ?, ?> t) {
+                                      final Transformer<A, ?, ?> t,
+                                      final Class<A> typeParameterClass) {
     Function1<T, Option<A>> g = JavaOps.optionalFn(f);
     Option<A> o = Option.apply(defaultValue);
-    return wrap(self.optional(g, o, t));
+    return wrap(self.optional(g, o, t, JavaOps.typeTag(typeParameterClass)));
   }
 
   /**

--- a/java/src/main/scala/com/spotify/featran/java/JavaOps.scala
+++ b/java/src/main/scala/com/spotify/featran/java/JavaOps.scala
@@ -43,7 +43,7 @@ private object JavaOps {
     val m = runtimeMirror(clazz.getClassLoader)
     val tpe = m.classSymbol(clazz).toType
     val typeCreator = new scala.reflect.api.TypeCreator {
-      def apply[U <: Universe with Singleton](m1: scala.reflect.api.Mirror[U]): U # Type =
+      def apply[U <: Universe with Singleton](m1: scala.reflect.api.Mirror[U]): U#Type =
         if (m1 != m) throw new RuntimeException("wrong mirror") else tpe.asInstanceOf[U#Type]
     }
     TypeTag[T](m, typeCreator)

--- a/java/src/main/scala/com/spotify/featran/java/JavaOps.scala
+++ b/java/src/main/scala/com/spotify/featran/java/JavaOps.scala
@@ -30,8 +30,24 @@ import org.tensorflow.example.Example
 import scala.collection.JavaConverters._
 import scala.language.higherKinds
 import scala.reflect.ClassTag
+import com.spotify.featran.transformers._
+import scala.reflect.runtime.universe.TypeTag
+
+import scala.reflect.api.Universe
 
 private object JavaOps {
+
+  def typeTag[T](clazz: Class[T]): TypeTag[T] = {
+    import scala.reflect.runtime.universe._
+    val classTag = ClassTag[T](clazz)
+    val m = runtimeMirror(clazz.getClassLoader)
+    val tpe = m.classSymbol(clazz).toType
+    val typeCreator = new scala.reflect.api.TypeCreator {
+      def apply[U <: Universe with Singleton](m1: scala.reflect.api.Mirror[U]): U # Type =
+        if (m1 != m) throw new RuntimeException("wrong mirror") else tpe.asInstanceOf[U#Type]
+    }
+    TypeTag[T](m, typeCreator)
+  }
 
   def requiredFn[I, O](f: SerializableFunction[I, O]): I => O =
     (input: I) => f(input)

--- a/java/src/test/java/com/spotify/featran/java/JavaTestUtil.java
+++ b/java/src/test/java/com/spotify/featran/java/JavaTestUtil.java
@@ -29,19 +29,19 @@ public class JavaTestUtil {
 
   public static JFeatureSpec<Tuple2<String, Integer>> spec() {
     return JFeatureSpec.<Tuple2<String, Integer>>create()
-        .required(t -> t._1, OneHotEncoder.apply("one_hot", false), String.class)
-        .required(t -> t._2.doubleValue(), MinMaxScaler.apply("min_max", 0.0, 1.0), Double.class);
+        .required(t -> t._1, OneHotEncoder.apply("one_hot", false))
+        .required(t -> t._2.doubleValue(), MinMaxScaler.apply("min_max", 0.0, 1.0));
   }
 
   public static JFeatureSpec<String> optionalSpec() {
     return JFeatureSpec.<String>create()
-        .optional(Optional::ofNullable, OneHotEncoder.apply("one_hot", false), String.class);
+        .optional(Optional::ofNullable, OneHotEncoder.apply("one_hot", false));
   }
 
   public static JFeatureSpec<Tuple2<String, String>> crossSpec() {
     return JFeatureSpec.<Tuple2<String, String>>create()
-        .required(t -> t._1, OneHotEncoder.apply("one_hot_a", false), String.class)
-        .required(t -> t._2, OneHotEncoder.apply("one_hot_b", false), String.class)
+        .required(t -> t._1, OneHotEncoder.apply("one_hot_a", false))
+        .required(t -> t._2, OneHotEncoder.apply("one_hot_b", false))
         .cross("one_hot_a", "one_hot_b", (a, b) -> a * b);
   }
 

--- a/java/src/test/java/com/spotify/featran/java/JavaTestUtil.java
+++ b/java/src/test/java/com/spotify/featran/java/JavaTestUtil.java
@@ -29,19 +29,19 @@ public class JavaTestUtil {
 
   public static JFeatureSpec<Tuple2<String, Integer>> spec() {
     return JFeatureSpec.<Tuple2<String, Integer>>create()
-        .required(t -> t._1, OneHotEncoder.apply("one_hot", false))
-        .required(t -> t._2.doubleValue(), MinMaxScaler.apply("min_max", 0.0, 1.0));
+        .required(t -> t._1, OneHotEncoder.apply("one_hot", false), String.class)
+        .required(t -> t._2.doubleValue(), MinMaxScaler.apply("min_max", 0.0, 1.0), Double.class);
   }
 
   public static JFeatureSpec<String> optionalSpec() {
     return JFeatureSpec.<String>create()
-        .optional(Optional::ofNullable, OneHotEncoder.apply("one_hot", false));
+        .optional(Optional::ofNullable, OneHotEncoder.apply("one_hot", false), String.class);
   }
 
   public static JFeatureSpec<Tuple2<String, String>> crossSpec() {
     return JFeatureSpec.<Tuple2<String, String>>create()
-        .required(t -> t._1, OneHotEncoder.apply("one_hot_a", false))
-        .required(t -> t._2, OneHotEncoder.apply("one_hot_b", false))
+        .required(t -> t._1, OneHotEncoder.apply("one_hot_a", false), String.class)
+        .required(t -> t._2, OneHotEncoder.apply("one_hot_b", false), String.class)
         .cross("one_hot_a", "one_hot_b", (a, b) -> a * b);
   }
 

--- a/java/src/test/java/com/spotify/featran/java/examples/JavaExample.java
+++ b/java/src/test/java/com/spotify/featran/java/examples/JavaExample.java
@@ -54,8 +54,8 @@ public class JavaExample {
 
     // Start building a feature specification
     JFeatureSpec<Record> fs = JFeatureSpec.<Record>create()
-        .required(r -> r.d, MinMaxScaler.apply("min-max", 0.0, 1.0), Double.class)
-        .optional(r -> r.s, OneHotEncoder.apply("one-hot", false), String.class);
+        .required(r -> r.d, MinMaxScaler.apply("min-max", 0.0, 1.0))
+        .optional(r -> r.s, OneHotEncoder.apply("one-hot", false));
 
     // Extract features from List<Record>
     JFeatureExtractor<Record> f1 = fs.extract(records);

--- a/java/src/test/java/com/spotify/featran/java/examples/JavaExample.java
+++ b/java/src/test/java/com/spotify/featran/java/examples/JavaExample.java
@@ -28,7 +28,7 @@ import java.util.*;
 public class JavaExample {
 
   private static class Record {
-    private final double d;
+    private final Double d;
     private final Optional<String> s;
 
     Record(double d, Optional<String> s) {
@@ -54,8 +54,8 @@ public class JavaExample {
 
     // Start building a feature specification
     JFeatureSpec<Record> fs = JFeatureSpec.<Record>create()
-        .required(r -> r.d, MinMaxScaler.apply("min-max", 0.0, 1.0))
-        .optional(r -> r.s, OneHotEncoder.apply("one-hot", false));
+        .required(r -> r.d, MinMaxScaler.apply("min-max", 0.0, 1.0), Double.class)
+        .optional(r -> r.s, OneHotEncoder.apply("one-hot", false), String.class);
 
     // Extract features from List<Record>
     JFeatureExtractor<Record> f1 = fs.extract(records);

--- a/scio/src/test/scala/com/spotify/featran/scio/ScioTest.scala
+++ b/scio/src/test/scala/com/spotify/featran/scio/ScioTest.scala
@@ -23,7 +23,9 @@ import com.spotify.scio.testing._
 
 object DummyConverter {
   import scala.reflect.runtime.universe._
-  implicit val tfConverter = new Converter[String, String] {
+  implicit val tfConverter: Converter[String] = new Converter[String] {
+    type RT = String
+
     def apply[A, B](name: String, typ: Type, fn: A => Option[B]): A => String = { (v: A) =>
       s"$name"
     }

--- a/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
+++ b/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
@@ -83,7 +83,7 @@ package object tensorflow {
           List(NamedTFFeature(name, f))
 
         case t if t <:< typeOf[Seq[String]] =>
-          v.asInstanceOf[Seq[String]].toList.map{category =>
+          v.asInstanceOf[Seq[String]].toList.map { category =>
             val f = Feature
               .newBuilder()
               .setBytesList(BytesList.newBuilder().addValue(ByteString.copyFromUtf8(category)))
@@ -117,7 +117,10 @@ package object tensorflow {
 
           val vfeature = Feature
             .newBuilder()
-            .setFloatList(FloatList.newBuilder().addAllValue(values.map(v => float2Float(v.value.toFloat)).asJava))
+            .setFloatList(
+              FloatList
+                .newBuilder()
+                .addAllValue(values.map(v => float2Float(v.value.toFloat)).asJava))
             .build()
 
           List(NamedTFFeature(name + "_key", kfeature), NamedTFFeature(name + "_key", vfeature))
@@ -127,11 +130,11 @@ package object tensorflow {
     }
   }
 
-  implicit val tfConverter = new Converter[tf.Example]{
+  implicit val tfConverter = new Converter[tf.Example] {
     def convert[T](row: T, feat: List[Feature[T, _, _, _]]): tf.Example = {
       val builder = Features.newBuilder()
-      feat.foreach{f =>
-        f.convert[List[NamedTFFeature]](row).foreach{opt =>
+      feat.foreach { f =>
+        f.convert[List[NamedTFFeature]](row).foreach { opt =>
           opt.foreach { nf =>
             builder.putFeature(nf.name, nf.f)
           }

--- a/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
+++ b/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
@@ -17,11 +17,17 @@
 
 package com.spotify.featran
 
-import org.tensorflow.example.{Example, Features}
+import com.google.protobuf.ByteString
+import com.spotify.featran.transformers.{ConvertFunction, Converter, WeightedLabel}
+import org.tensorflow.example._
 import org.tensorflow.{example => tf}
 
-package object tensorflow {
+import scala.reflect.runtime.universe._
+import scala.collection.JavaConverters._
 
+case class NamedTFFeature(name: String, f: tf.Feature)
+
+package object tensorflow {
   case class TensorFlowFeatureBuilder(
     @transient private val underlying: Features.Builder = tf.Features.newBuilder())
       extends FeatureBuilder[tf.Example] {
@@ -45,4 +51,90 @@ package object tensorflow {
    * [[FeatureBuilder]] for output as TensorFlow `Example` type.
    */
   implicit def tensorFlowFeatureBuilder: FeatureBuilder[tf.Example] = TensorFlowFeatureBuilder()
+
+  // scalastyle:off
+  implicit val converterFunction = new ConvertFunction[List[NamedTFFeature]] {
+    def apply[T: TypeTag](name: String, v: T): List[NamedTFFeature] = {
+      typeOf[T] match {
+        case t if t =:= typeOf[Double] =>
+          val f = Feature
+            .newBuilder()
+            .setFloatList(
+              FloatList
+                .newBuilder()
+                .addAllValue(Seq(float2Float(v.asInstanceOf[Double].toFloat)).asJava)
+            )
+            .build()
+          List(NamedTFFeature(name, f))
+
+        case t if t =:= typeOf[String] =>
+          val str = v.asInstanceOf[String]
+          val f = Feature
+            .newBuilder()
+            .setBytesList(BytesList.newBuilder().addValue(ByteString.copyFromUtf8(str)))
+            .build()
+
+          List(NamedTFFeature(name, f))
+
+        case t if t <:< typeOf[Seq[String]] =>
+          v.asInstanceOf[Seq[String]].toList.map{category =>
+            val f = Feature
+              .newBuilder()
+              .setBytesList(BytesList.newBuilder().addValue(ByteString.copyFromUtf8(category)))
+              .build()
+
+            NamedTFFeature(name, f)
+          }
+
+        case t if t <:< typeOf[Seq[Double]] =>
+          val values = v.asInstanceOf[Seq[Double]].map(v => float2Float(v.toFloat))
+          val f = Feature
+            .newBuilder()
+            .setFloatList(
+              FloatList
+                .newBuilder()
+                .addAllValue(values.asJava)
+            )
+            .build()
+
+          List(NamedTFFeature(name, f))
+
+        case t if t <:< typeOf[Seq[WeightedLabel]] =>
+          val values = v.asInstanceOf[Seq[WeightedLabel]]
+
+          val strs = values.map(v => ByteString.copyFromUtf8(v.name))
+
+          val kfeature = Feature
+            .newBuilder()
+            .setBytesList(BytesList.newBuilder().addAllValue(strs.asJava))
+            .build()
+
+          val vfeature = Feature
+            .newBuilder()
+            .setFloatList(FloatList.newBuilder().addAllValue(values.map(v => float2Float(v.value.toFloat)).asJava))
+            .build()
+
+          List(NamedTFFeature(name + "_key", kfeature), NamedTFFeature(name + "_key", vfeature))
+
+        case _ => Nil
+      }
+    }
+  }
+
+  implicit val tfConverter = new Converter[tf.Example]{
+    def convert[T](row: T, feat: List[Feature[T, _, _, _]]): tf.Example = {
+      val builder = Features.newBuilder()
+      feat.foreach{f =>
+        f.convert[List[NamedTFFeature]](row).foreach{opt =>
+          opt.foreach { nf =>
+            builder.putFeature(nf.name, nf.f)
+          }
+        }
+      }
+      Example
+        .newBuilder()
+        .setFeatures(builder.build())
+        .build()
+    }
+  }
 }

--- a/tensorflow/src/test/scala/com/spotify/featran/tensorflow/TensorFlowFeatureBuilderSpec.scala
+++ b/tensorflow/src/test/scala/com/spotify/featran/tensorflow/TensorFlowFeatureBuilderSpec.scala
@@ -17,12 +17,8 @@
 
 package com.spotify.featran.tensorflow
 
-<<<<<<< HEAD
-import com.spotify.featran.{FeatureBuilder, FeatureSpec}
 import com.spotify.featran.transformers.Identity
-=======
-import com.spotify.featran.{FeatureBuilder, SerializableUtils}
->>>>>>> master
+import com.spotify.featran.{FeatureBuilder, FeatureSpec, SerializableUtils}
 import org.scalacheck._
 import org.tensorflow.example.{Example, Feature, Features, FloatList}
 
@@ -60,17 +56,13 @@ object TensorFlowFeatureBuilderSpec extends Properties("TensorFlowFeatureBuilder
     actual == expected
   }
 
-<<<<<<< HEAD
-  private val id = Identity("id")
-  private val id2 = Identity("id2")
-
   property("converter") = Prop.forAll { xs: List[Record] =>
-    val f = FeatureSpec.of[Record].required(_.d)(id).convert(xs)
+    val f = FeatureSpec.of[Record].required(_.d)(Identity("id")).convert(xs)
     Prop.all(
       f.map(_.getFeatures.getFeatureMap.get("id").getFloatList.getValue(0)) == xs.map(_.d.toFloat)
     )
   }
-=======
+
   property("feature names") = Prop.forAll { key: String =>
     val fb = SerializableUtils.ensureSerializable(FeatureBuilder[Example])
     fb.init(1)
@@ -78,6 +70,4 @@ object TensorFlowFeatureBuilderSpec extends Properties("TensorFlowFeatureBuilder
     val actual = fb.result.getFeatures.getFeatureMap.keySet().iterator().next()
     Prop.all(actual.length == key.length, actual.replaceAll("[^A-Za-z0-9_]", "_") == actual)
   }
-
->>>>>>> master
 }


### PR DESCRIPTION
The general idea behind this review is to allow for a function that can use the internal functions from Featran to map to a new data type such as JSON or TFExample.  This becomes useful in conjunction with another #153 so that a pipeline can generate the settings file and this function in this PR can convert to TFExamples prior to saving to BigTable.

This PR is the cleanest way I could think of implementing this change and allow for flexibility.  In the future we may also want to provide a JSON converted that can be used directly in Facets Dive.  The major issue is around the TypeTag addition.  Everything works as expected but things get complex on the Java.  Currently this function is not exposed on the java side because the TypeTag is passed as null to not need to change the API.  We could also ask users to pass in the class of the function output but this would break the API and not be ideal for users.