### PR TITLE
Convert function between Scala Objects and a Flat Keyed Type

### DIFF
--- a/core/src/main/scala/com/spotify/featran/FlatConverter.scala
+++ b/core/src/main/scala/com/spotify/featran/FlatConverter.scala
@@ -1,0 +1,55 @@
+package com.spotify.featran
+
+import com.spotify.featran.transformers.{MDLRecord, WeightedLabel}
+import simulacrum.typeclass
+
+import scala.reflect.ClassTag
+
+/**
+ * TypeClass for implementing the writer to a flat format keyed by name
+ */
+@typeclass trait FlatWriter[+T] extends Serializable {
+  type IF
+
+  def writeDouble(name: String): Option[Double] => IF
+
+  def writeMdlRecord(name: String): Option[MDLRecord[String]] => IF
+
+  def writeWeightedLabel(name: String): Option[Seq[WeightedLabel]] => IF
+
+  def writeDoubles(name: String): Option[Seq[Double]] => IF
+
+  def writeDoubleArray(name: String): Option[Array[Double]] => IF
+
+  def writeString(name: String): Option[String] => IF
+
+  def writeStrings(name: String): Option[Seq[String]] => IF
+
+  def writer: Seq[IF] => T
+}
+
+/**
+ * Companion to FlatReader.  Sometimes for serialization and compatability reasons it
+ * is better to write out data in an intermediate format such as JSON or tf.examples to
+ * interface with storage or other systems.  This class uses the functions internal to a spec
+ * to write out the data into a new flat format.
+ */
+object FlatConverter {
+  def apply[T: ClassTag, A: ClassTag: FlatWriter](spec: FeatureSpec[T]): FlatConverter[T, A] =
+    new FlatConverter[T, A](spec)
+}
+
+private[featran] class FlatConverter[T: ClassTag, A: ClassTag: FlatWriter](spec: FeatureSpec[T]) {
+  import CollectionType.ops._
+
+  def convert[M[_]: CollectionType](col: M[T]): M[A] = {
+    val writer = FlatWriter[A].writer
+    val fns = spec.features.map{feature =>
+      (t: T) => feature.transformer.unsafeFlatWriter.apply(feature.f(t))
+    }.toList
+    col.map{record =>
+      val cols = fns.map(f => f(record))
+      writer.apply(cols)
+    }
+  }
+}

--- a/core/src/main/scala/com/spotify/featran/FlatConverter.scala
+++ b/core/src/main/scala/com/spotify/featran/FlatConverter.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.featran
 
 import com.spotify.featran.transformers.{MDLRecord, WeightedLabel}
@@ -44,10 +61,10 @@ private[featran] class FlatConverter[T: ClassTag, A: ClassTag: FlatWriter](spec:
 
   def convert[M[_]: CollectionType](col: M[T]): M[A] = {
     val writer = FlatWriter[A].writer
-    val fns = spec.features.map{feature =>
-      (t: T) => feature.transformer.unsafeFlatWriter.apply(feature.f(t))
+    val fns = spec.features.map { feature => (t: T) =>
+      feature.transformer.unsafeFlatWriter.apply(feature.f(t))
     }.toList
-    col.map{record =>
+    col.map { record =>
       val cols = fns.map(f => f(record))
       writer.apply(cols)
     }

--- a/core/src/main/scala/com/spotify/featran/FlatExtractor.scala
+++ b/core/src/main/scala/com/spotify/featran/FlatExtractor.scala
@@ -56,7 +56,8 @@ object FlatExtractor {
     new FlatExtractor[M, T](setCol)
 }
 
-private[featran] class FlatExtractor[M[_]: CollectionType, T: ClassTag: FlatReader](settings: M[String])
+private[featran] class FlatExtractor[M[_]: CollectionType, T: ClassTag: FlatReader](
+  settings: M[String])
     extends Serializable {
 
   import CollectionType.ops._

--- a/core/src/main/scala/com/spotify/featran/FlatExtractor.scala
+++ b/core/src/main/scala/com/spotify/featran/FlatExtractor.scala
@@ -43,11 +43,6 @@ import scala.reflect.ClassTag
   def readStrings(name: String): T => Option[Seq[String]]
 }
 
-object FlatExtractor {
-  def apply[M[_]: CollectionType, T: ClassTag: FlatReader](setCol: M[String]): FlatExtractor[M, T] =
-    new FlatExtractor[M, T](setCol)
-}
-
 /**
  * Sometimes it is useful to store the features in an intermediate state in normally
  * a flat version like Examples or maybe JSON.  This makes it easier to interface with
@@ -55,12 +50,13 @@ object FlatExtractor {
  *
  * This function allows the reading of data from these flat versions by name with a given
  * settings file to extract the final output.
- *
- * @param settings Settings file used to read and transform the data
- * @tparam M Collection Type
- * @tparam T The intermediate storage format for each feature.
  */
-class FlatExtractor[M[_]: CollectionType, T: ClassTag: FlatReader](settings: M[String])
+object FlatExtractor {
+  def apply[M[_]: CollectionType, T: ClassTag: FlatReader](setCol: M[String]): FlatExtractor[M, T] =
+    new FlatExtractor[M, T](setCol)
+}
+
+private[featran] class FlatExtractor[M[_]: CollectionType, T: ClassTag: FlatReader](settings: M[String])
     extends Serializable {
 
   import CollectionType.ops._

--- a/core/src/main/scala/com/spotify/featran/transformers/Binarizer.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/Binarizer.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.FlatReader
+import com.spotify.featran.{FlatReader, FlatWriter}
 
 /**
  * Transform numerical features to binary features.
@@ -52,4 +52,6 @@ private[featran] class Binarizer(name: String, val threshold: Double) extends Ma
     Map("threshold" -> threshold.toString)
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDouble(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Double] => fw.IF =
+    fw.writeDouble(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/Bucketizer.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/Bucketizer.scala
@@ -19,7 +19,7 @@ package com.spotify.featran.transformers
 
 import java.util.{TreeMap => JTreeMap}
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 import com.twitter.algebird.{Aggregator, HLL}
 
 /**
@@ -102,4 +102,6 @@ private[featran] class Bucketizer(name: String, val splits: Array[Double])
     Map("splits" -> splits.mkString("[", ",", "]"))
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDouble(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Double] => fw.IF =
+    fw.writeDouble(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/HashNHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/HashNHotEncoder.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FlatReader, FlatWriter}
 import com.twitter.algebird.HLL
 
 import scala.collection.SortedSet
@@ -97,4 +97,6 @@ private[featran] class HashNHotEncoder(name: String, hashBucketSize: Int, sizeSc
   }
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readStrings(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Seq[String]] => fw.IF =
+    fw.writeStrings(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/HashNHotWeightedEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/HashNHotWeightedEncoder.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FlatReader, FlatWriter}
 import com.twitter.algebird.HLL
 
 import scala.collection.JavaConverters._
@@ -105,4 +105,6 @@ private[featran] class HashNHotWeightedEncoder(name: String,
   }
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readWeightedLabel(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Seq[WeightedLabel]] => fw.IF =
+    fw.writeWeightedLabel(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/HashOneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/HashOneHotEncoder.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FlatReader, FlatWriter}
 import com.twitter.algebird._
 
 import scala.math.ceil
@@ -95,6 +95,8 @@ private[featran] class HashOneHotEncoder(name: String,
   }
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readString(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[String] => fw.IF =
+    fw.writeString(name)
 }
 
 private[featran] abstract class BaseHashHotEncoder[A](name: String,

--- a/core/src/main/scala/com/spotify/featran/transformers/HeavyHitters.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/HeavyHitters.scala
@@ -19,7 +19,7 @@ package com.spotify.featran.transformers
 
 import java.net.{URLDecoder, URLEncoder}
 
-import com.spotify.featran.{FeatureBuilder, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FlatReader, FlatWriter}
 import com.twitter.algebird._
 
 import scala.util.Random
@@ -129,5 +129,6 @@ private[featran] class HeavyHitters(name: String,
         "heavyHittersCount" -> heavyHittersCount.toString)
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readString(name)
-
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[String] => fw.IF =
+    fw.writeString(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/Identity.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/Identity.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.FlatReader
+import com.spotify.featran.{FlatReader, FlatWriter}
 
 /**
  * Transform features by passing them through.
@@ -42,4 +42,6 @@ object Identity extends SettingsBuilder {
 private[featran] class Identity(name: String) extends MapOne[Double](name) {
   override def map(a: Double): Double = a
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDouble(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Double] => fw.IF =
+    fw.writeDouble(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/MDL.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/MDL.scala
@@ -19,7 +19,7 @@ package com.spotify.featran.transformers
 
 import java.util.{TreeMap => JTreeMap}
 
-import com.spotify.featran.{FeatureBuilder, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FlatReader, FlatWriter}
 import com.spotify.featran.transformers.MinMaxScaler.C
 import com.spotify.featran.transformers.mdl.MDLPDiscretizer
 import com.spotify.featran.transformers.mdl.MDLPDiscretizer._
@@ -168,5 +168,8 @@ private[featran] class MDL[T: ClassTag](name: String,
       "seed" -> seed.toString
     )
 
-  def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDouble(name)
+  def flatRead[A: FlatReader]: A => Option[Any] = FlatReader[A].readMdlRecord(name)
+  def flatWriter[A](implicit fw: FlatWriter[A]): Option[MDLRecord[T]] => fw.IF =
+    (v: Option[MDLRecord[T]]) =>
+      fw.writeMdlRecord(name)(v.map(r => MDLRecord(r.label.toString, r.value)))
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/MaxAbsScaler.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/MaxAbsScaler.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 import com.twitter.algebird.{Aggregator, Max}
 
 /**
@@ -62,4 +62,6 @@ private[featran] class MaxAbsScaler(name: String)
   override def encodeAggregator(c: Double): String = c.toString
   override def decodeAggregator(s: String): Double = s.toDouble
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDouble(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Double] => fw.IF =
+    fw.writeDouble(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/MinMaxScaler.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/MinMaxScaler.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 import com.twitter.algebird.{Aggregator, Max, Min}
 
 import scala.collection.SortedMap
@@ -89,4 +89,6 @@ private[featran] class MinMaxScaler(name: String, val min: Double, val max: Doub
     Map("min" -> min.toString, "max" -> max.toString)
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDouble(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Double] => fw.IF =
+    fw.writeDouble(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/NHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/NHotEncoder.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 
 import scala.collection.SortedMap
 import scala.collection.mutable.{Set => MSet}
@@ -96,4 +96,6 @@ private[featran] class NHotEncoder(name: String, encodeMissingValue: Boolean)
   }
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readStrings(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Seq[String]] => fw.IF =
+    fw.writeStrings(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/NHotWeightedEncoder.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 
 import scala.collection.SortedMap
 import scala.collection.mutable.{Map => MMap, Set => MSet}
@@ -115,4 +115,6 @@ private[featran] class NHotWeightedEncoder(name: String, encodeMissingValue: Boo
   }
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readWeightedLabel(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Seq[WeightedLabel]] => fw.IF =
+    fw.writeWeightedLabel(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/Normalizer.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/Normalizer.scala
@@ -18,7 +18,7 @@
 package com.spotify.featran.transformers
 
 import breeze.linalg._
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 import com.twitter.algebird.Aggregator
 
 /**
@@ -78,4 +78,6 @@ private[featran] class Normalizer(name: String, val p: Double, val expectedLengt
     Map("p" -> p.toString, "expectedLength" -> expectedLength.toString)
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDoubleArray(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Array[Double]] => fw.IF =
+    fw.writeDoubleArray(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/OneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/OneHotEncoder.scala
@@ -19,7 +19,7 @@ package com.spotify.featran.transformers
 
 import java.net.{URLDecoder, URLEncoder}
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 import com.twitter.algebird.Aggregator
 
 import scala.collection.SortedMap
@@ -78,6 +78,8 @@ private[featran] class OneHotEncoder(name: String, encodeMissingValue: Boolean)
   }
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readString(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[String] => fw.IF =
+    fw.writeString(name)
 }
 
 private[featran] object MissingValue {

--- a/core/src/main/scala/com/spotify/featran/transformers/PolynomialExpansion.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/PolynomialExpansion.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 import com.twitter.algebird.Aggregator
 
 /**
@@ -120,6 +120,8 @@ private[featran] class PolynomialExpansion(name: String, val degree: Int, val ex
     Map("degree" -> degree.toString, "expectedLength" -> expectedLength.toString)
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDoubleArray(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Array[Double]] => fw.IF =
+    fw.writeDoubleArray(name)
 }
 
 // Ported from commons-math3

--- a/core/src/main/scala/com/spotify/featran/transformers/PositionEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/PositionEncoder.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 
 import scala.collection.SortedMap
 
@@ -69,4 +69,6 @@ private[featran] class PositionEncoder(name: String) extends BaseHotEncoder[Stri
   }
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readString(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[String] => fw.IF =
+    fw.writeString(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/QuantileDiscretizer.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/QuantileDiscretizer.scala
@@ -19,7 +19,7 @@ package com.spotify.featran.transformers
 
 import java.util.{TreeMap => JTreeMap}
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 import com.twitter.algebird._
 
 import scala.collection.JavaConverters._
@@ -120,4 +120,6 @@ private[featran] class QuantileDiscretizer(name: String, val numBuckets: Int, va
     Map("numBuckets" -> numBuckets.toString, "k" -> k.toString)
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDouble(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Double] => fw.IF =
+    fw.writeDouble(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/QuantileOutlierRejector.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/QuantileOutlierRejector.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 import com.twitter.algebird._
 
 /**
@@ -140,4 +140,6 @@ private abstract class BaseQuantileRejector(name: String, val numBuckets: Int, v
     Map("numBuckets" -> numBuckets.toString, "k" -> k.toString)
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDouble(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Double] => fw.IF =
+    fw.writeDouble(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/StandardScaler.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/StandardScaler.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FlatReader, FlatWriter}
 import com.twitter.algebird.{Aggregator, Moments}
 
 /**
@@ -76,4 +76,6 @@ private[featran] class StandardScaler(name: String, val withStd: Boolean, val wi
     Map("withStd" -> withStd.toString, "withMean" -> withMean.toString)
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDouble(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Double] => fw.IF =
+    fw.writeDouble(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/TopNOneHotEncoder.scala
@@ -19,7 +19,7 @@ package com.spotify.featran.transformers
 
 import java.net.{URLDecoder, URLEncoder}
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 import com.twitter.algebird.{Aggregator, SketchMap, SketchMapParams}
 
 import scala.collection.SortedMap
@@ -154,4 +154,6 @@ private[featran] class TopNOneHotEncoder(name: String,
         "encodeMissingValue" -> encodeMissingValue.toString)
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readString(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[String] => fw.IF =
+    fw.writeString(name)
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/Transformer.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/Transformer.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FlatReader, JsonSerializable}
+import com.spotify.featran.{FeatureBuilder, FlatReader, FlatWriter, JsonSerializable}
 import com.twitter.algebird.{Aggregator, Semigroup}
 
 trait SettingsBuilder {
@@ -96,6 +96,9 @@ abstract class Transformer[-A, B, C](val name: String) extends Serializable {
     optFeatureDimension(c.asInstanceOf[Option[C]])
 
   def flatRead[T: FlatReader]: T => Option[Any]
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[A] => fw.IF
+  def unsafeFlatWriter[T](implicit fw: FlatWriter[T]): Option[Any] => fw.IF =
+    (o: Option[Any]) => flatWriter.apply(o.asInstanceOf[Option[A]]).asInstanceOf[fw.IF]
 
   //================================================================================
   // Transformer parameter and aggregator persistence

--- a/core/src/main/scala/com/spotify/featran/transformers/VectorIdentity.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/VectorIdentity.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.featran.transformers
 
-import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
 import com.twitter.algebird.Aggregator
 
 /**
@@ -74,4 +74,6 @@ private[featran] class VectorIdentity[M[_]](name: String, val expectedLength: In
     Map("expectedLength" -> expectedLength.toString)
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDoubles(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[M[Double]] => fw.IF =
+    (v: Option[M[Double]]) => fw.writeDoubles(name)(v.map(_.asInstanceOf[Seq[Double]]))
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/VonMisesEvaluator.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/VonMisesEvaluator.scala
@@ -18,7 +18,7 @@
 package com.spotify.featran.transformers
 
 import breeze.stats.distributions.VonMises
-import com.spotify.featran.{FeatureBuilder, FlatReader}
+import com.spotify.featran.{FeatureBuilder, FlatReader, FlatWriter}
 import com.twitter.algebird.Aggregator
 
 /**
@@ -95,4 +95,6 @@ private[featran] class VonMisesEvaluator(name: String,
         "points" -> points.mkString("[", ",", "]"))
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDouble(name)
+  def flatWriter[T](implicit fw: FlatWriter[T]): Option[Double] => fw.IF =
+    fw.writeDouble(name)
 }

--- a/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
+++ b/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
@@ -108,12 +108,11 @@ package object tensorflow {
     type IF = List[NamedTFFeature]
 
     override def writeDouble(name: String): Option[Double] => List[NamedTFFeature] =
-      (v: Option[Double]) =>
-        v.toList.map(r => NamedTFFeature(name, fromDoubles(Seq(r)).build()))
+      (v: Option[Double]) => v.toList.map(r => NamedTFFeature(name, fromDoubles(Seq(r)).build()))
 
     override def writeMdlRecord(name: String): Option[MDLRecord[String]] => List[NamedTFFeature] =
       (v: Option[MDLRecord[String]]) => {
-        v.toList.flatMap{values =>
+        v.toList.flatMap { values =>
           List(
             NamedTFFeature(name + "_label", fromStrings(Seq(values.label.toString)).build()),
             NamedTFFeature(name + "_value", fromDoubles(Seq(values.value)).build())
@@ -132,11 +131,11 @@ package object tensorflow {
       }
 
     override def writeDoubles(name: String): Option[Seq[Double]] => List[NamedTFFeature] =
-        (v: Option[Seq[Double]]) => {
-          v.toList.flatMap { values =>
-            List(NamedTFFeature(name, fromDoubles(values).build()))
-          }
+      (v: Option[Seq[Double]]) => {
+        v.toList.flatMap { values =>
+          List(NamedTFFeature(name, fromDoubles(values).build()))
         }
+      }
 
     override def writeDoubleArray(name: String): Option[Array[Double]] => List[NamedTFFeature] =
       (v: Option[Array[Double]]) => {
@@ -162,7 +161,7 @@ package object tensorflow {
     override def writer: Seq[List[NamedTFFeature]] => Example =
       (fns: Seq[List[NamedTFFeature]]) => {
         val builder = Features.newBuilder()
-        fns.foreach{f =>
+        fns.foreach { f =>
           f.foreach { nf =>
             builder.putFeature(nf.name, nf.f)
           }

--- a/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
+++ b/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
@@ -24,6 +24,8 @@ import _root_.java.util.regex.Pattern
 import com.spotify.featran.transformers.{MDLRecord, WeightedLabel}
 import shapeless.datatype.tensorflow.TensorFlowType
 
+case class NamedTFFeature(name: String, f: tf.Feature)
+
 package object tensorflow {
   private val FeatureNameNormalization = Pattern.compile("[^A-Za-z0-9_]")
 
@@ -99,6 +101,77 @@ package object tensorflow {
 
     def readStrings(name: String): Example => Option[Seq[String]] =
       (ex: Example) => toFeature(name, ex).map(v => toStrings(v))
+  }
+
+  implicit val exampleFlatWriter: FlatWriter[Example] = new FlatWriter[tf.Example] {
+    import TensorFlowType._
+    type IF = List[NamedTFFeature]
+
+    override def writeDouble(name: String): Option[Double] => List[NamedTFFeature] =
+      (v: Option[Double]) =>
+        v.toList.map(r => NamedTFFeature(name, fromDoubles(Seq(r)).build()))
+
+    override def writeMdlRecord(name: String): Option[MDLRecord[String]] => List[NamedTFFeature] =
+      (v: Option[MDLRecord[String]]) => {
+        v.toList.flatMap{values =>
+          List(
+            NamedTFFeature(name + "_label", fromStrings(Seq(values.label.toString)).build()),
+            NamedTFFeature(name + "_value", fromDoubles(Seq(values.value)).build())
+          )
+        }
+      }
+
+    override def writeWeightedLabel(n: String): Option[Seq[WeightedLabel]] => List[NamedTFFeature] =
+      (v: Option[Seq[WeightedLabel]]) => {
+        v.toList.flatMap { values =>
+          List(
+            NamedTFFeature(n + "_key", fromStrings(values.map(_.name)).build()),
+            NamedTFFeature(n + "_value", fromDoubles(values.map(_.value)).build())
+          )
+        }
+      }
+
+    override def writeDoubles(name: String): Option[Seq[Double]] => List[NamedTFFeature] =
+        (v: Option[Seq[Double]]) => {
+          v.toList.flatMap { values =>
+            List(NamedTFFeature(name, fromDoubles(values).build()))
+          }
+        }
+
+    override def writeDoubleArray(name: String): Option[Array[Double]] => List[NamedTFFeature] =
+      (v: Option[Array[Double]]) => {
+        v.toList.flatMap { values =>
+          List(NamedTFFeature(name, fromDoubles(values).build()))
+        }
+      }
+
+    override def writeString(name: String): Option[String] => List[NamedTFFeature] =
+      (v: Option[String]) => {
+        v.toList.flatMap { values =>
+          List(NamedTFFeature(name, fromStrings(Seq(values)).build()))
+        }
+      }
+
+    override def writeStrings(name: String): Option[Seq[String]] => List[NamedTFFeature] =
+      (v: Option[Seq[String]]) => {
+        v.toList.flatMap { values =>
+          List(NamedTFFeature(name, fromStrings(values).build()))
+        }
+      }
+
+    override def writer: Seq[List[NamedTFFeature]] => Example =
+      (fns: Seq[List[NamedTFFeature]]) => {
+        val builder = Features.newBuilder()
+        fns.foreach{f =>
+          f.foreach { nf =>
+            builder.putFeature(nf.name, nf.f)
+          }
+        }
+        Example
+          .newBuilder()
+          .setFeatures(builder.build())
+          .build()
+      }
   }
 
   /**

--- a/tensorflow/src/test/scala/com/spotify/featran/tensorflow/ExampleConverterSpec.scala
+++ b/tensorflow/src/test/scala/com/spotify/featran/tensorflow/ExampleConverterSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.featran.tensorflow
 
 import com.spotify.featran.{FeatureSpec, FlatConverter}

--- a/tensorflow/src/test/scala/com/spotify/featran/tensorflow/ExampleConverterSpec.scala
+++ b/tensorflow/src/test/scala/com/spotify/featran/tensorflow/ExampleConverterSpec.scala
@@ -1,0 +1,82 @@
+package com.spotify.featran.tensorflow
+
+import com.spotify.featran.{FeatureSpec, FlatConverter}
+import com.spotify.featran.transformers.{MDLRecord, WeightedLabel}
+import org.scalacheck._
+import com.spotify.featran.transformers._
+
+import scala.collection.JavaConverters._
+
+class ExampleConverterSpec extends Properties("ExampleConverterSpec") {
+  import shapeless.datatype.tensorflow.TensorFlowType._
+  case class Record(d: Double, optD: Option[Double])
+  case class TransformerTypes(
+    d: Double,
+    s: String,
+    ds: List[Double],
+    ss: List[String],
+    we: List[WeightedLabel],
+    mdl: MDLRecord[String]
+  )
+
+  private def list[T](implicit arb: Arbitrary[Option[T]]): Gen[List[Option[T]]] =
+    Gen.listOfN(100, arb.arbitrary)
+
+  implicit val arbRecords: Arbitrary[List[Record]] = Arbitrary {
+    Gen.listOfN(100, Arbitrary.arbitrary[(Double, Option[Double])].map(Record.tupled))
+  }
+
+  implicit val arbTypes: Arbitrary[List[TransformerTypes]] = Arbitrary {
+    Gen.listOfN(
+      100,
+      Arbitrary
+        .arbitrary[(Float, String)]
+        .map {
+          case (num, str) =>
+            TransformerTypes(
+              num.toDouble,
+              str,
+              List(num.toDouble),
+              List(str),
+              List(WeightedLabel(str, num.toDouble)),
+              MDLRecord(str, num.toDouble)
+            )
+        }
+    )
+  }
+
+  property("converter") = Prop.forAll { xs: List[Record] =>
+    val spec = FeatureSpec.of[Record].required(_.d)(Identity("id"))
+    val f = FlatConverter(spec).convert(xs)
+    Prop.all(
+      f.map(_.getFeatures.getFeatureMap.get("id").getFloatList.getValue(0)) == xs.map(_.d.toFloat)
+    )
+  }
+
+  property("converter all types") = Prop.forAll { xs: List[TransformerTypes] =>
+    val spec = FeatureSpec
+      .of[TransformerTypes]
+      .required(_.d)(Identity("d"))
+      .required(_.s)(OneHotEncoder("s"))
+      .required(_.ds)(VectorIdentity("ds"))
+      .required(_.ss)(NHotEncoder("ss"))
+      .required(_.we)(NHotWeightedEncoder("we"))
+      .required(_.mdl)(MDL("mdl"))
+
+    val f = FlatConverter(spec).convert(xs)
+
+    val results = f.map { ex =>
+      val fm = ex.getFeatures.getFeatureMap.asScala
+      TransformerTypes(
+        toDoubles(fm("d")).head,
+        toStrings(fm("s")).head,
+        toDoubles(fm("ds")).toList,
+        toStrings(fm("ss")).toList,
+        List(WeightedLabel(toStrings(fm("we_key")).head, toDoubles(fm("we_value")).head)),
+        MDLRecord(toStrings(fm("mdl_label")).head, toDoubles(fm("mdl_value")).head)
+      )
+    }
+
+    Prop.all(results == xs)
+  }
+}


### PR DESCRIPTION
This PR adds a new TypeClass and function that allows a user to use the functions internal to a FeatureSpec to convert to a new flat keyed feature type.  This review adds support for tf.examples but json and tablerows are other examples of possible converters.