### PR TITLE
Functions to convert Spec to FlatSpec to allow aggregations from keyed sources.

### DIFF
--- a/core/src/main/scala/com/spotify/featran/FlatExtractor.scala
+++ b/core/src/main/scala/com/spotify/featran/FlatExtractor.scala
@@ -49,6 +49,7 @@ import scala.reflect.ClassTag
  * other systems.
  */
 object FlatExtractor {
+
   /**
    * This function allows the reading of data from these flat versions by name with a given
    * settings file to extract the final output.
@@ -71,7 +72,7 @@ object FlatExtractor {
    * @return FeatureSpec for the intermediate format
    */
   def flatSpec[T: ClassTag: FlatReader, X: ClassTag](spec: FeatureSpec[X]): FeatureSpec[T] = {
-    val features = spec.features.map{feature =>
+    val features = spec.features.map { feature =>
       val t = feature.transformer.asInstanceOf[Transformer[Any, _, _]]
       new Feature(feature.transformer.flatRead, feature.default, t)
         .asInstanceOf[Feature[T, _, _, _]]
@@ -88,9 +89,9 @@ object FlatExtractor {
    * @tparam X The Input Scala Object
    * @return FeatureSpec for the intermediate format
    */
-  def multiFlatSpec[T: ClassTag: FlatReader, X: ClassTag](spec: MultiFeatureSpec[X])
-    : MultiFeatureSpec[T] = {
-    val features = spec.features.map{feature =>
+  def multiFlatSpec[T: ClassTag: FlatReader, X: ClassTag](
+    spec: MultiFeatureSpec[X]): MultiFeatureSpec[T] = {
+    val features = spec.features.map { feature =>
       val t = feature.transformer.asInstanceOf[Transformer[Any, _, _]]
       new Feature(feature.transformer.flatRead, feature.default, t)
         .asInstanceOf[Feature[T, _, _, _]]

--- a/core/src/main/scala/com/spotify/featran/MultiFeatureSpec.scala
+++ b/core/src/main/scala/com/spotify/featran/MultiFeatureSpec.scala
@@ -42,7 +42,7 @@ object MultiFeatureSpec {
  */
 class MultiFeatureSpec[T](private[featran] val mapping: Map[String, Int],
                           private[featran] val features: Array[Feature[T, _, _, _]],
-                          private val crossings: Crossings) {
+                          private[featran] val crossings: Crossings) {
 
   private def multiFeatureSet: MultiFeatureSet[T] =
     new MultiFeatureSet[T](features, crossings, mapping)


### PR DESCRIPTION
Followup to the past few PRs.  These functions allow the conversion from a known FeatureSpec on some type T to a Spec that can read and extract data from the intermediate keyed sources that are now possible to map between.

Example would be earlier using the Spec to convert T to tf.examples and now wanting to generate a settings file from these examples stored somewhere.