### PR TITLE
Add JSON Reader/Writer to Core

### DIFF
--- a/core/src/main/scala/com/spotify/featran/FlatExtractor.scala
+++ b/core/src/main/scala/com/spotify/featran/FlatExtractor.scala
@@ -131,7 +131,11 @@ private[featran] class FlatExtractor[M[_]: CollectionType, T: ClassTag: FlatRead
     }.sum
   }
 
-  def featureValues[F: FeatureBuilder: ClassTag](records: M[T]): M[F] = {
+  def featureValues[F: FeatureBuilder: ClassTag](records: M[T]): M[F] =
+    featureResults(records).map(_._1)
+
+  def featureResults[F: FeatureBuilder: ClassTag](
+    records: M[T]): M[(F, Map[String, FeatureRejection])] = {
     val fb = FeatureBuilder[F].newBuilder
     records.cross(converters).cross(dimSize).map {
       case ((record, convs), size) =>
@@ -141,7 +145,7 @@ private[featran] class FlatExtractor[M[_]: CollectionType, T: ClassTag: FlatRead
             val a = aggr.map(conv.decodeAggregator)
             conv.unsafeBuildFeatures(fn(record), a, fb)
         }
-        fb.result
+        (fb.result, fb.rejections)
     }
   }
 }

--- a/core/src/main/scala/com/spotify/featran/json/package.scala
+++ b/core/src/main/scala/com/spotify/featran/json/package.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.featran
+
+import com.spotify.featran.transformers.{MDLRecord, WeightedLabel}
+import io.circe._
+import io.circe.parser._
+
+/**
+ * Package for an intermediate format for feature storage using JSON
+ */
+package object json {
+  implicit val jsonFlatReader: FlatReader[String] = new FlatReader[String] {
+    private def toJson(str: String): Option[Json] = {
+      val parsed = parse(str)
+      if (parsed.isLeft) None else Some(parsed.right.get)
+    }
+
+    private def toFeature(str: String, name: String): Option[Json] =
+      for {
+        keyedJson <- toJson(str)
+        jsonObj <- keyedJson.asObject
+        feature <- jsonObj.apply(name)
+      } yield feature
+
+    override def readDouble(name: String): String => Option[Double] =
+      (jsonStr: String) =>
+        for {
+          feature <- toFeature(jsonStr, name)
+          number <- feature.asNumber
+        } yield number.toDouble
+
+    override def readMdlRecord(name: String): String => Option[MDLRecord[String]] =
+      (jsonStr: String) =>
+        for {
+          feature <- toFeature(jsonStr, name)
+          obj <- feature.asObject
+          label <- obj.keys.headOption
+          valueObj <- obj.values.headOption
+          num <- valueObj.asNumber
+        } yield MDLRecord(label, num.toDouble)
+
+    override def readWeightedLabel(name: String): String => Option[List[WeightedLabel]] =
+      (jsonStr: String) => {
+        val weights = for {
+          feature <- toFeature(jsonStr, name).toList
+          objs <- feature.asArray.toList.flatten
+          obj <- objs.asObject.toList
+          name <- obj.keys
+          values <- obj.values
+          num <- values.asNumber
+        } yield WeightedLabel(name, num.toDouble)
+        if (weights.isEmpty) None else Some(weights)
+      }
+
+    override def readDoubles(name: String): String => Option[Seq[Double]] =
+      (jsonStr: String) => {
+        val items = for {
+          feature <- toFeature(jsonStr, name).toList
+          objOpt <- feature.asArray.toList
+          obj <- objOpt
+          number <- obj.asNumber
+        } yield number.toDouble
+        if (items.isEmpty) None else Some(items)
+      }
+
+    override def readDoubleArray(name: String): String => Option[Array[Double]] = {
+      val doubles = readDoubles(name)
+      (jsonStr: String) =>
+        doubles(jsonStr).map(_.toArray)
+    }
+
+    override def readString(name: String): String => Option[String] =
+      (jsonStr: String) =>
+        for {
+          feature <- toFeature(jsonStr, name)
+          str <- feature.asString
+        } yield str
+
+    override def readStrings(name: String): String => Option[Seq[String]] =
+      (jsonStr: String) => {
+        val items = for {
+          feature <- toFeature(jsonStr, name).toList
+          objOpt <- feature.asArray.toList
+          obj <- objOpt
+          str <- obj.asString
+        } yield str
+        if (items.isEmpty) None else Some(items)
+      }
+  }
+
+  implicit val jsonFlatWriter: FlatWriter[String] = new FlatWriter[String] {
+    override type IF = (String, Option[Json])
+
+    override def writeDouble(name: String): Option[Double] => (String, Option[Json]) =
+      (v: Option[Double]) => (name, v.flatMap(Json.fromDouble))
+
+    override def writeMdlRecord(name: String): Option[MDLRecord[String]] => (String, Option[Json]) =
+      (v: Option[MDLRecord[String]]) => {
+        val json = for {
+          record <- v
+          jsonDouble <- Json.fromDouble(record.value)
+        } yield Json.obj((record.label, jsonDouble))
+        (name, json)
+      }
+
+    override def writeWeightedLabel(
+      name: String): Option[Seq[WeightedLabel]] => (String, Option[Json]) =
+      (v: Option[Seq[WeightedLabel]]) => {
+        val json = v.map { weights =>
+          val keyValues = weights.flatMap { weight =>
+            Json.fromDouble(weight.value).map { w =>
+              (weight.name, w)
+            }
+          }
+          Json.fromValues(keyValues.map(t => Json.obj(t)))
+        }
+        (name, json)
+      }
+
+    override def writeDoubles(name: String): Option[Seq[Double]] => (String, Option[Json]) =
+      (v: Option[Seq[Double]]) => (name, v.map(r => Json.fromValues(r.flatMap(Json.fromDouble))))
+
+    override def writeDoubleArray(name: String): Option[Array[Double]] => (String, Option[Json]) =
+      (v: Option[Array[Double]]) => (name, v.map(r => Json.fromValues(r.flatMap(Json.fromDouble))))
+
+    override def writeString(name: String): Option[String] => (String, Option[Json]) =
+      (v: Option[String]) => (name, v.map(Json.fromString))
+
+    override def writeStrings(name: String): Option[Seq[String]] => (String, Option[Json]) =
+      (v: Option[Seq[String]]) => (name, v.map(r => Json.fromValues(r.map(Json.fromString))))
+
+    override def writer: Seq[(String, Option[Json])] => String =
+      (v: Seq[(String, Option[Json])]) =>
+        Json.obj(v.collect { case (n, Some(json)) => (n, json) }: _*).noSpaces
+  }
+}

--- a/core/src/main/scala/com/spotify/featran/transformers/Bucketizer.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/Bucketizer.scala
@@ -57,7 +57,7 @@ object Bucketizer extends SettingsBuilder {
   def fromSettings(setting: Settings): Transformer[Double, Unit, Unit] = {
     val params = setting.params
     val str = params("splits")
-    val splits = str.slice(1, str.length - 1).split(",").map(_.toDouble)
+    val splits = str.slice(1, str.length - 1).split(",").map(_.toDouble).sorted
     Bucketizer(setting.name, splits)
   }
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/VectorIdentity.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/VectorIdentity.scala
@@ -75,5 +75,5 @@ private[featran] class VectorIdentity[M[_]](name: String, val expectedLength: In
 
   def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readDoubles(name)
   def flatWriter[T](implicit fw: FlatWriter[T]): Option[M[Double]] => fw.IF =
-    (v: Option[M[Double]]) => fw.writeDoubles(name)(v.map(_.asInstanceOf[Seq[Double]]))
+    (v: Option[M[Double]]) => fw.writeDoubles(name)(v.map(_.toSeq))
 }

--- a/core/src/main/scala/com/spotify/featran/transformers/VonMisesEvaluator.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/VonMisesEvaluator.scala
@@ -52,7 +52,7 @@ object VonMisesEvaluator extends SettingsBuilder {
     val params = setting.params
     val k = params("kappa").toDouble
     val s = params("scale").toDouble
-    val str = params("point")
+    val str = params("points")
     val points = str.slice(1, str.length - 1).split(",").map(_.toDouble)
     VonMisesEvaluator(setting.name, k, s, points)
   }

--- a/core/src/test/scala/com/spotify/featran/transformers/BucketizerSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/BucketizerSpec.scala
@@ -25,8 +25,12 @@ object BucketizerSpec extends TransformerProp("Bucketizer") {
     Gen.choose(3, 10).flatMap(n => Gen.listOfN(n, Arbitrary.arbitrary[Double]))
 
   property("default") = Prop.forAll(list[Double].arbitrary, SplitsGen) { (xs, sp) =>
-    val splits = sp.toArray.sorted
-    test(xs, splits)
+    val uniq = sp.distinct
+    if (uniq.size < 3) {
+      Prop.passed
+    } else {
+      test(xs, uniq.toArray.sorted)
+    }
   }
 
   // last bucket should be inclusive

--- a/core/src/test/scala/com/spotify/featran/transformers/BucketizerSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/BucketizerSpec.scala
@@ -25,12 +25,7 @@ object BucketizerSpec extends TransformerProp("Bucketizer") {
     Gen.choose(3, 10).flatMap(n => Gen.listOfN(n, Arbitrary.arbitrary[Double]))
 
   property("default") = Prop.forAll(list[Double].arbitrary, SplitsGen) { (xs, sp) =>
-    val uniq = sp.distinct
-    if (uniq.size < 3) {
-      Prop.passed
-    } else {
-      test(xs, uniq.toArray.sorted)
-    }
+    test(xs, sp.toArray.sorted)
   }
 
   // last bucket should be inclusive

--- a/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
@@ -48,12 +48,12 @@ abstract class TransformerProp(name: String) extends Properties(name) {
 
   // scalastyle:off method.length
   def test[T: ClassTag](t: Transformer[T, _, _],
-                        input: List[T],
-                        names: Seq[String],
-                        expected: List[Seq[Double]],
-                        missing: Seq[Double],
-                        outOfBoundsElems: List[(T, Seq[Double])] = Nil,
-                        rejected: List[Seq[Double]] = Nil): Prop = {
+    input: List[T],
+    names: Seq[String],
+    expected: List[Seq[Double]],
+    missing: Seq[Double],
+    outOfBoundsElems: List[(T, Seq[Double])] = Nil,
+    rejected: List[Seq[Double]] = Nil): Prop = {
     val fsRequired = FeatureSpec.of[T].required(identity)(t)
     val fsOptional = FeatureSpec.of[Option[T]].optional(identity)(t)
 

--- a/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
@@ -20,11 +20,14 @@ package com.spotify.featran.transformers
 import breeze.linalg.SparseVector
 
 import scala.collection.Set
-import com.spotify.featran.FeatureSpec
+import com.spotify.featran.{FeatureSpec, FlatConverter, FlatExtractor}
 import org.scalacheck.Prop.BooleanOperators
 import org.scalacheck._
 
+import scala.reflect.ClassTag
+
 abstract class TransformerProp(name: String) extends Properties(name) {
+  import com.spotify.featran.json._
 
   implicit def list[T](implicit arb: Arbitrary[T]): Arbitrary[List[T]] =
     Arbitrary {
@@ -44,13 +47,13 @@ abstract class TransformerProp(name: String) extends Properties(name) {
     xs.map(_.map(d2e)) == ys.map(_.map(d2e))
 
   // scalastyle:off method.length
-  def test[T](t: Transformer[T, _, _],
-              input: List[T],
-              names: Seq[String],
-              expected: List[Seq[Double]],
-              missing: Seq[Double],
-              outOfBoundsElems: List[(T, Seq[Double])] = Nil,
-              rejected: List[Seq[Double]] = Nil): Prop = {
+  def test[T: ClassTag](t: Transformer[T, _, _],
+                        input: List[T],
+                        names: Seq[String],
+                        expected: List[Seq[Double]],
+                        missing: Seq[Double],
+                        outOfBoundsElems: List[(T, Seq[Double])] = Nil,
+                        rejected: List[Seq[Double]] = Nil): Prop = {
     val fsRequired = FeatureSpec.of[T].required(identity)(t)
     val fsOptional = FeatureSpec.of[Option[T]].optional(identity)(t)
 
@@ -74,7 +77,7 @@ abstract class TransformerProp(name: String) extends Properties(name) {
     val f4results = f4.featureResults[Seq[Double]]
     val c = f1.featureValues[Seq[Double]]
 
-    Prop.all(
+    val propStandard = Prop.all(
       "f1 names" |: f1.featureNames == List(names),
       "f2 names" |: f2.featureNames == List(names),
       "f3 names" |: f3.featureNames == List(names),
@@ -101,6 +104,36 @@ abstract class TransformerProp(name: String) extends Properties(name) {
       "f3 settings" |: settings == f3.featureSettings,
       "f4 settings" |: settings == f4.featureSettings
     )
+
+    val flatRequired = FlatExtractor.flatSpec[String, T](fsRequired)
+    val flatOptional = FlatExtractor.flatSpec[String, Option[T]](fsOptional)
+
+    val converterRequired = FlatConverter[T, String](fsRequired)
+    val converterOptional = FlatConverter[Option[T], String](fsOptional)
+
+    val examplesReq = converterRequired.convert(input)
+    val examplesOpt = converterOptional.convert(input.map(Some(_)) :+ None)
+
+    val flatEx = flatRequired.extract(examplesReq)
+    val flatExOpt = flatRequired.extract(examplesOpt)
+
+    val flatFeatures = FlatExtractor[List, String](flatEx.featureSettings)
+      .featureValues[Seq[Double]](examplesReq)
+
+    val flatFeaturesOpt = FlatExtractor[List, String](flatExOpt.featureSettings)
+      .featureValues[Seq[Double]](examplesOpt)
+
+//    println("++++++++++++++++++++++++++++++++++++++++++++++++++++++")
+//    println(expected.map(_.mkString(":")).mkString(","))
+//    println(flatFeatures.map(_.mkString(":")).mkString(","))
+//    println("++++++++++++++++++++++++++++++++++++++++++++++++++++++")
+
+    val propConverters = Prop.all(
+      "f1 values flat" |: safeCompare(flatFeatures, expected),
+      "f1 values flat opt" |: safeCompare(flatFeaturesOpt, expected :+ missing)
+    )
+
+    Prop.all(propStandard, propConverters)
   }
   // scalastyle:on method.length
 

--- a/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
@@ -118,7 +118,7 @@ abstract class TransformerProp(name: String) extends Properties(name) {
     val examplesOpt = converterOptional.convert(input.map(Some(_)) :+ None)
 
     val flatEx = flatRequired.extract(examplesReq)
-    val flatExOpt = flatRequired.extract(examplesOpt)
+    val flatExOpt = flatOptional.extract(examplesOpt)
 
     val flatMultiSettings = flatMulti.extract(examplesReq).featureSettings
     val multiSettings = multiSpec.extract(input).featureSettings

--- a/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/TransformerProp.scala
@@ -48,12 +48,12 @@ abstract class TransformerProp(name: String) extends Properties(name) {
 
   // scalastyle:off method.length
   def test[T: ClassTag](t: Transformer[T, _, _],
-    input: List[T],
-    names: Seq[String],
-    expected: List[Seq[Double]],
-    missing: Seq[Double],
-    outOfBoundsElems: List[(T, Seq[Double])] = Nil,
-    rejected: List[Seq[Double]] = Nil): Prop = {
+                        input: List[T],
+                        names: Seq[String],
+                        expected: List[Seq[Double]],
+                        missing: Seq[Double],
+                        outOfBoundsElems: List[(T, Seq[Double])] = Nil,
+                        rejected: List[Seq[Double]] = Nil): Prop = {
     val fsRequired = FeatureSpec.of[T].required(identity)(t)
     val fsOptional = FeatureSpec.of[Option[T]].optional(identity)(t)
 

--- a/core/src/test/scala/com/spotify/featran/transformers/VectorIdentitySpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/VectorIdentitySpec.scala
@@ -21,19 +21,19 @@ import org.scalacheck.Prop
 
 object VectorIdentitySpec extends TransformerProp("VectorIdentity") {
 
-  property("default") = Prop.forAll { xs: List[Array[Double]] =>
+  property("default") = Prop.forAll { xs: List[List[Double]] =>
     val dim = xs.head.length
     val names = (0 until dim).map("id_" + _)
     val expected = xs.map(_.toSeq)
     val missing = (0 until dim).map(_ => 0.0)
     val oob = List((xs.head :+ 1.0, missing)) // vector of different dimension
-    test[Array[Double]](VectorIdentity("id"), xs, names, expected, missing, oob)
+    test[List[Double]](VectorIdentity("id"), xs, names, expected, missing, oob)
   }
 
-  property("length") = Prop.forAll { xs: List[Array[Double]] =>
+  property("length") = Prop.forAll { xs: List[List[Double]] =>
     val msg = "requirement failed: Invalid input length, " +
       s"expected: ${xs.head.length + 1}, actual: ${xs.head.length}"
-    testException[Array[Double]](VectorIdentity("id", xs.head.length + 1), xs) { e =>
+    testException[List[Double]](VectorIdentity("id", xs.head.length + 1), xs) { e =>
       e.isInstanceOf[IllegalArgumentException] && e.getMessage == msg
     }
   }

--- a/core/src/test/scala/com/spotify/featran/transformers/VonMisesEvaluatorSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/VonMisesEvaluatorSpec.scala
@@ -33,16 +33,12 @@ object VonMisesEvaluatorSpec extends TransformerProp("VonMisesEvaluator") {
 
   property("default") = Prop.forAll(MuGen, PointGen, KappaGen) { (xs, points, kappa) =>
     val dim = points.size
-    if (dim > 0) {
-      val names = (0 until dim).map("vm_" + _)
-      val missing = (0 until dim).map(_ => 0.0)
-      val expected = xs.map { mu =>
-        points.map(p => VonMises(mu * Scale, kappa).pdf(Scale * p))
-      }
-      test(VonMisesEvaluator("vm", kappa, Scale, points.toArray), xs, names, expected, missing)
-    } else {
-      Prop.passed
+    val names = (0 until dim).map("vm_" + _)
+    val missing = (0 until dim).map(_ => 0.0)
+    val expected = xs.map { mu =>
+      points.map(p => VonMises(mu * Scale, kappa).pdf(Scale * p))
     }
+    test(VonMisesEvaluator("vm", kappa, Scale, points.toArray), xs, names, expected, missing)
   }
 
 }

--- a/core/src/test/scala/com/spotify/featran/transformers/VonMisesEvaluatorSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/VonMisesEvaluatorSpec.scala
@@ -33,12 +33,16 @@ object VonMisesEvaluatorSpec extends TransformerProp("VonMisesEvaluator") {
 
   property("default") = Prop.forAll(MuGen, PointGen, KappaGen) { (xs, points, kappa) =>
     val dim = points.size
-    val names = (0 until dim).map("vm_" + _)
-    val missing = (0 until dim).map(_ => 0.0)
-    val expected = xs.map { mu =>
-      points.map(p => VonMises(mu * Scale, kappa).pdf(Scale * p))
+    if (dim > 0) {
+      val names = (0 until dim).map("vm_" + _)
+      val missing = (0 until dim).map(_ => 0.0)
+      val expected = xs.map { mu =>
+        points.map(p => VonMises(mu * Scale, kappa).pdf(Scale * p))
+      }
+      test(VonMisesEvaluator("vm", kappa, Scale, points.toArray), xs, names, expected, missing)
+    } else {
+      Prop.passed
     }
-    test(VonMisesEvaluator("vm", kappa, Scale, points.toArray), xs, names, expected, missing)
   }
 
 }


### PR DESCRIPTION
This adds a new package to core that allows for reading/writing to a JSON intermediate format.  Also because we have this typeclass implemented in core the converters can be added to transformers to make sure it works everywhere.