### PR TITLE
Revert TensorFlow to 1.8.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val scaldingVersion = "0.17.4"
 val scioVersion = "0.5.5"
 val simulacrumVersion = "0.12.0"
 val sparkVersion = "2.3.0"
-val tensorflowVersion = "1.9.0"
+val tensorflowVersion = "1.8.0"
 val xgBoostVersion = "0.72-20180627-1214081f"
 val shapelessDatatypeVersion = "0.1.9"
 


### PR DESCRIPTION
@ravwojdyla found a potential issue with the new version. Let's do this in the next release.