### PR TITLE
Allow empty sequences as input values for HashNHotEncoders

### DIFF
--- a/core/src/main/scala/com/spotify/featran/transformers/HashNHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/HashNHotEncoder.scala
@@ -80,7 +80,7 @@ object HashNHotEncoder extends SettingsBuilder {
 private[featran] class HashNHotEncoder(name: String, hashBucketSize: Int, sizeScalingFactor: Double)
     extends BaseHashHotEncoder[Seq[String]](name, hashBucketSize, sizeScalingFactor) {
   override def prepare(a: Seq[String]): HLL =
-    a.map(hllMonoid.toHLL(_)).reduce(hllMonoid.plus)
+    a.map(hllMonoid.toHLL(_)).fold(hllMonoid.zero)(hllMonoid.plus)
 
   override def buildFeatures(a: Option[Seq[String]], c: Int, fb: FeatureBuilder[_]): Unit = {
     a match {

--- a/core/src/main/scala/com/spotify/featran/transformers/HashNHotWeightedEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/HashNHotWeightedEncoder.scala
@@ -85,7 +85,7 @@ private[featran] class HashNHotWeightedEncoder(
 ) extends BaseHashHotEncoder[Seq[WeightedLabel]](name, hashBucketSize, sizeScalingFactor) {
 
   override def prepare(a: Seq[WeightedLabel]): HLL =
-    a.map(_.name).map(hllMonoid.toHLL(_)).reduce(hllMonoid.plus)
+    a.map(_.name).map(hllMonoid.toHLL(_)).fold(hllMonoid.zero)(hllMonoid.plus)
 
   override def buildFeatures(a: Option[Seq[WeightedLabel]], c: Int, fb: FeatureBuilder[_]): Unit = {
     a match {


### PR DESCRIPTION
This PR enables using empty sequences as input values for `HashNHotEncoder` and `HashNHotWeightedEncoder`.