### PR TITLE
Bump scalafmt to 2.5.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.4.2"
+version = "2.5.1"
 maxColumn = 100
 
 binPack.literalArgumentLists = true
@@ -9,9 +9,13 @@ continuationIndent {
 }
 
 newlines {
-  afterImplicitKWInVerticalMultiline = true
-  beforeImplicitKWInVerticalMultiline = true
+  alwaysBeforeMultilineDef = false
   sometimesBeforeColonInMethodReturnType = true
+}
+
+verticalMultiline {
+  newlineAfterImplicitKW = true
+  newlineBeforeImplicitKW = true
 }
 
 docstrings = JavaDoc
@@ -20,4 +24,6 @@ project.git = false
 
 rewrite {
   rules = [PreferCurlyFors, RedundantBraces, RedundantParens, SortImports]
+  redundantBraces.generalExpressions = false
+  redundantBraces.maxLines = 1
 }

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,12 @@ lazy val publishSettings = Seq(
   credentials ++= (for {
     username <- sys.env.get("SONATYPE_USERNAME")
     password <- sys.env.get("SONATYPE_PASSWORD")
-  } yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq,
+  } yield Credentials(
+    "Sonatype Nexus Repository Manager",
+    "oss.sonatype.org",
+    username,
+    password
+  )).toSeq,
   publishTo := sonatypePublishToBundle.value,
   releaseCrossBuild := true,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,

--- a/core/src/main/scala/com/spotify/featran/CollectionType.scala
+++ b/core/src/main/scala/com/spotify/featran/CollectionType.scala
@@ -37,8 +37,8 @@ import scala.reflect.ClassTag
 }
 
 object CollectionType {
-  implicit def scalaCollectionType[M[_]](
-    implicit cb: CanBuild[_, M],
+  implicit def scalaCollectionType[M[_]](implicit
+    cb: CanBuild[_, M],
     ti: M[_] => Iterable[_]
   ): CollectionType[M] =
     new CollectionType[M] {

--- a/core/src/main/scala/com/spotify/featran/CrossingFeatureBuilder.scala
+++ b/core/src/main/scala/com/spotify/featran/CrossingFeatureBuilder.scala
@@ -104,8 +104,8 @@ private class CrossingFeatureBuilder[F] private (
     }
     fb.add(name, value)
   }
-  override def add[M[_]](names: Iterable[String], values: M[Double])(
-    implicit ev: M[Double] => Seq[Double]
+  override def add[M[_]](names: Iterable[String], values: M[Double])(implicit
+    ev: M[Double] => Seq[Double]
   ): Unit = {
     if (xEnabled) {
       val i = names.iterator

--- a/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
@@ -99,8 +99,8 @@ object FeatureRejection {
    * Add multiple feature values. The total number of values added and skipped should equal to
    * dimension in [[init]].
    */
-  def add[M[_]](names: Iterable[String], values: M[Double])(
-    implicit ev: M[Double] => Seq[Double]
+  def add[M[_]](names: Iterable[String], values: M[Double])(implicit
+    ev: M[Double] => Seq[Double]
   ): Unit = {
     val i = names.iterator
     val j = values.iterator
@@ -179,8 +179,8 @@ case class NamedSparseArray[@specialized(Float, Double) T](
 }
 
 object FeatureBuilder {
-  private final case class IterableFB[M[_], T: ClassTag: FloatingPoint]()(
-    implicit cb: CanBuild[T, M],
+  private final case class IterableFB[M[_], T: ClassTag: FloatingPoint]()(implicit
+    cb: CanBuild[T, M],
     ti: M[T] => Iterable[T]
   ) extends FeatureBuilder[M[T]] {
     private var underlying: mutable.Builder[T, M[T]] = null
@@ -200,8 +200,8 @@ object FeatureBuilder {
     override def newBuilder: FeatureBuilder[M[T]] = IterableFB[M, T]()
   }
 
-  implicit def iterableFB[M[_], T: ClassTag: FloatingPoint](
-    implicit cb: CanBuild[T, M],
+  implicit def iterableFB[M[_], T: ClassTag: FloatingPoint](implicit
+    cb: CanBuild[T, M],
     ti: M[T] => Iterable[T]
   ): FeatureBuilder[M[T]] = IterableFB[M, T]()
 

--- a/core/src/main/scala/com/spotify/featran/converters/CaseClassConverter.scala
+++ b/core/src/main/scala/com/spotify/featran/converters/CaseClassConverter.scala
@@ -42,8 +42,8 @@ object CaseClassConverter {
 
   // scalastyle:off cyclomatic.complexity
   // scalastyle:off method.length
-  def toSpec[T <: Product](
-    implicit tt: TypeTag[T],
+  def toSpec[T <: Product](implicit
+    tt: TypeTag[T],
     ct: ClassTag[T],
     d: DefaultTransform[Double]
   ): FeatureSpec[T] =

--- a/core/src/main/scala/com/spotify/featran/transformers/NHotEncoder.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/NHotEncoder.scala
@@ -59,8 +59,10 @@ private[featran] class NHotEncoder(name: String, encodeMissingValue: Boolean)
   import MissingValue.MissingValueToken
 
   def addMissingValue(fb: FeatureBuilder[_], unseen: MSet[String], keys: Seq[String]): Unit =
-    if (unseen.isEmpty
-        && keys.nonEmpty) {
+    if (
+      unseen.isEmpty
+      && keys.nonEmpty
+    ) {
       fb.skip()
     } else {
       fb.add(name + '_' + MissingValueToken, 1.0)

--- a/core/src/main/scala/com/spotify/featran/transformers/VectorIdentity.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/VectorIdentity.scala
@@ -36,8 +36,8 @@ object VectorIdentity extends SettingsBuilder {
    * Create a new [[VectorIdentity]] instance.
    * @param expectedLength expected length of the input vectors, or 0 to infer from data
    */
-  def apply[M[_]](name: String, expectedLength: Int = 0)(
-    implicit ev: M[Double] => Seq[Double]
+  def apply[M[_]](name: String, expectedLength: Int = 0)(implicit
+    ev: M[Double] => Seq[Double]
   ): Transformer[M[Double], Int, Int] =
     new VectorIdentity(name, expectedLength)(ev)
 
@@ -51,8 +51,8 @@ object VectorIdentity extends SettingsBuilder {
   }
 }
 
-private[featran] class VectorIdentity[M[_]](name: String, val expectedLength: Int)(
-  implicit ev: M[Double] => Seq[Double]
+private[featran] class VectorIdentity[M[_]](name: String, val expectedLength: Int)(implicit
+  ev: M[Double] => Seq[Double]
 ) extends Transformer[M[Double], Int, Int](name) {
   override val aggregator: Aggregator[M[Double], Int, Int] =
     Aggregators.seqLength(expectedLength)

--- a/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/FeatureSpecSpec.scala
@@ -31,9 +31,12 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
   }
 
   implicit val arbWrapperRecords: Arbitrary[List[RecordWrapper]] = Arbitrary {
-    Gen.listOfN(100, Arbitrary.arbitrary[(Double, Double, Option[Double])].map {
-      case (d1, d2, od) => RecordWrapper(Record(d2, od), d1)
-    })
+    Gen.listOfN(
+      100,
+      Arbitrary.arbitrary[(Double, Double, Option[Double])].map {
+        case (d1, d2, od) => RecordWrapper(Record(d2, od), d1)
+      }
+    )
   }
 
   private val id = Identity("id")
@@ -84,9 +87,12 @@ object FeatureSpecSpec extends Properties("FeatureSpec") {
   property("generator") = Prop.forAll { xs: List[Record] =>
     val spec = FeatureSpec.from[Record]
     val f = spec.extract(xs)
-    Prop.all(f.featureNames == Seq(Seq("d", "optD")), f.featureValues[Seq[Double]] == xs.map { r =>
-      r.optD.map(v => Seq(r.d, v)).getOrElse(Seq(r.d, 0.0))
-    })
+    Prop.all(
+      f.featureNames == Seq(Seq("d", "optD")),
+      f.featureValues[Seq[Double]] == xs.map { r =>
+        r.optD.map(v => Seq(r.d, v)).getOrElse(Seq(r.d, 0.0))
+      }
+    )
   }
 
   property("composite") = Prop.forAll { xs: List[Record] =>

--- a/numpy/src/main/scala/com/spotify/featran/numpy/NumPy.scala
+++ b/numpy/src/main/scala/com/spotify/featran/numpy/NumPy.scala
@@ -36,10 +36,10 @@ object NumPyType {
   // from Guava LittleEndianDataOutputStream
   implicit class LittleEndianOutputStream(private val out: OutputStream) extends AnyVal {
     def writeInt(v: Int): Unit = {
-      out.write(0xFF & v)
-      out.write(0xFF & (v >> 8))
-      out.write(0xFF & (v >> 16))
-      out.write(0xFF & (v >> 24))
+      out.write(0xff & v)
+      out.write(0xff & (v >> 8))
+      out.write(0xff & (v >> 16))
+      out.write(0xff & (v >> 24))
     }
 
     def writeLong(v: Long): Unit = {
@@ -47,7 +47,7 @@ object NumPyType {
       val result = new Array[Byte](8)
       var i = 7
       while (i >= 0) {
-        result(i) = (value & 0xFFL).toByte
+        result(i) = (value & 0xffL).toByte
         value >>= 8
         i -= 1
       }
@@ -118,8 +118,8 @@ object NumPy {
     val headerString = header(dimensions)
     // from Guava LittleEndianDataOutputStream#writeShort
     val l = headerString.length
-    out.write(0xFF & l)
-    out.write(0xFF & (l >> 8))
+    out.write(0xff & l)
+    out.write(0xff & (l >> 8))
     out.write(headerString.getBytes)
   }
 

--- a/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
+++ b/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
@@ -33,10 +33,13 @@ package object tensorflow {
     val normalize: String => String = {
       lazy val cache = new ConcurrentHashMap[String, String]()
       fn =>
-        cache.computeIfAbsent(fn, new Function[String, String] {
-          override def apply(n: String): String =
-            NamePattern.matcher(n).replaceAll("_")
-        })
+        cache.computeIfAbsent(
+          fn,
+          new Function[String, String] {
+            override def apply(n: String): String =
+              NamePattern.matcher(n).replaceAll("_")
+          }
+        )
     }
   }
 


### PR DESCRIPTION
The dangling implicits are new default:
https://scalameta.org/scalafmt/docs/configuration.html#newlines-around-implicit-parameter-list-modifier