### PR TITLE
Add Segment Indices transformer

### DIFF
--- a/core/src/main/scala/com/spotify/featran/CanBuild.scala
+++ b/core/src/main/scala/com/spotify/featran/CanBuild.scala
@@ -63,11 +63,7 @@ object CanBuild {
     override def apply(): mutable.Builder[T, Array[T]] = Array.newBuilder[T]
   }
 
-  implicit def IntSeqCB: CanBuild[Int, Seq] = new CanBuild[Int, Seq] {
-    override def apply(): mutable.Builder[Int, Seq[Int]] = Seq.newBuilder
-  }
-
-  implicit def IntArrayCB: CanBuild[Int, Array] = new CanBuild[Int, Array] {
+  implicit def intArrayCB: CanBuild[Int, Array] = new CanBuild[Int, Array] {
     override def apply(): mutable.Builder[Int, Array[Int]] = Array.newBuilder[Int]
   }
 }

--- a/core/src/main/scala/com/spotify/featran/CanBuild.scala
+++ b/core/src/main/scala/com/spotify/featran/CanBuild.scala
@@ -62,4 +62,12 @@ object CanBuild {
   implicit def arrayCB[T: ClassTag]: CanBuild[T, Array] = new CanBuild[T, Array] {
     override def apply(): mutable.Builder[T, Array[T]] = Array.newBuilder[T]
   }
+
+  implicit def IntSeqCB: CanBuild[Int, Seq] = new CanBuild[Int, Seq] {
+    override def apply(): mutable.Builder[Int, Seq[Int]] = Seq.newBuilder
+  }
+
+  implicit def IntArrayCB: CanBuild[Int, Array] = new CanBuild[Int, Array] {
+    override def apply(): mutable.Builder[Int, Array[Int]] = Array.newBuilder[Int]
+  }
 }

--- a/core/src/main/scala/com/spotify/featran/CrossingFeatureBuilder.scala
+++ b/core/src/main/scala/com/spotify/featran/CrossingFeatureBuilder.scala
@@ -117,6 +117,20 @@ private class CrossingFeatureBuilder[F] private (
     }
     fb.add(names, values)
   }
+
+  override def addInts[M[_]](names: Iterable[String], values: M[Int])(implicit
+                                                                      ev: M[Int] => Seq[Int]): Unit = {
+    if (xEnabled) {
+      val i = names.iterator
+      val j = values.iterator
+      while (i.hasNext && j.hasNext) {
+        xQueue.enqueue(CrossValue(i.next(), xOffset, j.next()))
+        xOffset += 1
+      }
+    }
+    fb.addInts(names, values)
+  }
+
   override def skip(): Unit = {
     xOffset += 1
     fb.skip()

--- a/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
@@ -109,6 +109,16 @@ object FeatureRejection {
     }
   }
 
+  def addInts[M[_]](names: Iterable[String], values: M[Int])(implicit
+                                                            ev: M[Int] => Seq[Int]
+  ): Unit = {
+    val i = names.iterator
+    val j = values.iterator
+    while (i.hasNext && j.hasNext) {
+      add(i.next(), j.next())
+    }
+  }
+
   /**
    * Skip multiple feature values. The total number of values added and skipped should equal to
    * dimension in [[init]].

--- a/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
+++ b/core/src/main/scala/com/spotify/featran/FeatureBuilder.scala
@@ -33,6 +33,7 @@ object FeatureRejection {
   case class Unseen(labels: Set[String]) extends FeatureRejection
   case class WrongDimension(expected: Int, actual: Int) extends FeatureRejection
   case class Outlier(actual: Double) extends FeatureRejection
+  case class InvalidInput(reason: String) extends FeatureRejection
   case object Collision extends FeatureRejection
 }
 

--- a/core/src/main/scala/com/spotify/featran/FlatConverter.scala
+++ b/core/src/main/scala/com/spotify/featran/FlatConverter.scala
@@ -42,6 +42,8 @@ import scala.annotation.implicitNotFound
 
   def writeStrings(name: String): Option[Seq[String]] => IF
 
+  def writeIntArray(name: String): Option[Array[Int]] => IF
+
   def writer: Seq[IF] => T
 }
 

--- a/core/src/main/scala/com/spotify/featran/FlatExtractor.scala
+++ b/core/src/main/scala/com/spotify/featran/FlatExtractor.scala
@@ -43,6 +43,8 @@ import scala.annotation.implicitNotFound
   def readString(name: String): T => Option[String]
 
   def readStrings(name: String): T => Option[Seq[String]]
+
+  def readIntArray(name: String): T => Option[Array[Int]]
 }
 
 object FlatReader {

--- a/core/src/main/scala/com/spotify/featran/FloatingPoint.scala
+++ b/core/src/main/scala/com/spotify/featran/FloatingPoint.scala
@@ -23,7 +23,7 @@ import scala.annotation.implicitNotFound
 
 /** Type class for floating point primitives. */
 @implicitNotFound("Could not find an instance of FloatingPoint for ${T}")
-@typeclass trait FloatingPoint[@specialized(Float, Double) T] extends Serializable {
+@typeclass trait FloatingPoint[@specialized(Float, Double, Int) T] extends Serializable {
   def fromDouble(x: Double): T
 }
 
@@ -33,6 +33,9 @@ object FloatingPoint {
   }
   implicit val doubleFP: FloatingPoint[Double] = new FloatingPoint[Double] {
     override def fromDouble(x: Double): Double = x
+  }
+  implicit val intFP: FloatingPoint[Int] = new FloatingPoint[Int] {
+    override def fromDouble(x: Double): Int = x.toInt
   }
 
   /* ======================================================================== */

--- a/core/src/main/scala/com/spotify/featran/json/Implicits.scala
+++ b/core/src/main/scala/com/spotify/featran/json/Implicits.scala
@@ -110,6 +110,9 @@ private[featran] trait Implicits extends Serializable {
 
     override def readStrings(name: String): String => Option[Seq[String]] =
       toFeature[Seq[String]](name)
+
+    override def readIntArray(name: String): String => Option[Array[Int]] =
+      toFeature[Array[Int]](name)
   }
 
   implicit val jsonFlatWriter: FlatWriter[String] = new FlatWriter[String] {
@@ -137,6 +140,9 @@ private[featran] trait Implicits extends Serializable {
 
     override def writeStrings(name: String): Option[Seq[String]] => (String, Option[Json]) =
       (v: Option[Seq[String]]) => (name, v.map(_.asJson))
+
+    override def writeIntArray(name: String): Option[Array[Int]] => (String, Option[Json]) =
+      (v: Option[Array[Int]]) => (name, v.map(_.asJson))
 
     override def writer: Seq[(String, Option[Json])] => String =
       _.asJson.noSpaces

--- a/core/src/main/scala/com/spotify/featran/transformers/Normalizer.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/Normalizer.scala
@@ -45,7 +45,7 @@ object Normalizer extends SettingsBuilder {
     new Normalizer(name, p, expectedLength)
 
   /**
-   * Create a new [[OneHotEncoder]] from a settings object
+   * Create a new [[Normalizer]] from a settings object
    * @param setting Settings object
    */
   def fromSettings(setting: Settings): Transformer[Array[Double], Int, Int] = {

--- a/core/src/main/scala/com/spotify/featran/transformers/SegmentIndices.scala
+++ b/core/src/main/scala/com/spotify/featran/transformers/SegmentIndices.scala
@@ -1,0 +1,71 @@
+package com.spotify.featran.transformers
+
+import com.spotify.featran.{FeatureBuilder, FeatureRejection, FlatReader, FlatWriter}
+import com.twitter.algebird.Aggregator
+
+object SegmentIndices extends SettingsBuilder {
+
+  /**
+   * Create a new [[SegmentIndices]] instance.
+   * @param expectedLength expected length of the input vectors, or 0 to infer from data
+   */
+  def apply(
+             name: String,
+             expectedLength: Int = 0
+           ): Transformer[Array[Int], Int, Int] =
+    new SegmentIndices(name, expectedLength)
+
+  /**
+   * Create a new [[SegmentIndices]] from a settings object
+   * @param setting Settings object
+   */
+  def fromSettings(setting: Settings): Transformer[Array[Int], Int, Int] = {
+    val expectedLength = setting.params("expectedLength").toInt
+    SegmentIndices(setting.name, expectedLength)
+  }
+}
+
+private[featran] class SegmentIndices(name: String, expectedLength: Int = 0)
+  extends Transformer[Array[Int], Int, Int](name) {
+
+  override val aggregator: Aggregator[Array[Int], Int, Int] =
+    Aggregators.seqLength(expectedLength)
+  override def featureDimension(c: Int): Int = c
+  override def featureNames(c: Int): Seq[String] = names(c)
+
+  override def buildFeatures(a: Option[Array[Int]], c: Int, fb: FeatureBuilder[_]): Unit = a match {
+    //TODO: Require increasing input (non-strict monotonic)
+    case Some(x) if (x.length != c) =>
+      fb.skip(c)
+      fb.reject(this, FeatureRejection.WrongDimension(c, x.length))
+    case Some(x) => {
+      val copyOfX = x.clone()
+
+      var tmp: Int = 0
+      copyOfX(0) = 0 //TODO: Set first element to 0, Guard against head being empty or non-zero
+
+      for (index <- 1 until copyOfX.length) { //Skip 0th!
+        val inputValue = copyOfX(index)
+
+        if (inputValue == tmp)
+          copyOfX(index) = copyOfX(index - 1) + 1
+        else
+          copyOfX(index) = 0
+        tmp = inputValue
+      }
+
+      fb.addInts(names = names(c), values = copyOfX)
+    }
+    case None => fb.skip(c)
+  }
+
+  override def encodeAggregator(c: Int): String = c.toString
+  override def decodeAggregator(s: String): Int = s.toInt
+  override def params: Map[String, String] =
+    Map("expectedLength" -> expectedLength.toString)
+
+  override def flatRead[T: FlatReader]: T => Option[Any] = FlatReader[T].readIntArray(name)
+
+  override def flatWriter[T](implicit fw: FlatWriter[T]): Option[Array[Int]] => fw.IF = fw.writeIntArray(name)
+
+}

--- a/core/src/test/scala/com/spotify/featran/transformers/SegmentIndicesSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/SegmentIndicesSpec.scala
@@ -1,0 +1,41 @@
+package com.spotify.featran.transformers
+
+import com.spotify.featran.FeatureSpec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+object SegmentIndicesSpec extends AnyFlatSpec with Matchers {
+
+  def main(args: Array[String]): Unit = {
+    def randomMonotonicIncreasingArray(): Array[Int] = {
+      val emptyArray = Array.fill(10)(0)
+      for (index <- 1 until emptyArray.length) {
+        if (math.random() > 0.5) {
+          emptyArray(index) = emptyArray(index - 1) + 1
+        } else
+          emptyArray(index) = emptyArray(index - 1)
+      }
+      emptyArray
+    }
+
+    val hundredRandomArrays = (1 to 100).toList.map(_ => randomMonotonicIncreasingArray())
+
+    val segmentedIndices = FeatureSpec
+      .of[Array[Int]]
+      .required(identity)(SegmentIndices("segmented"))
+
+    val expected = hundredRandomArrays.map { testCase =>
+      testCase.groupBy(identity).toSeq.sortBy(_._1).flatMap { case (_, sameNumber) =>
+        sameNumber.indices.toList }
+    }
+
+    val result = segmentedIndices.extract(hundredRandomArrays).featureValues[Seq[Int]]
+
+
+    result should equal(expected)
+  }
+//  property("default") = Prop.forAll(list[Array[Int]].arbitrary) {
+//    (xs) => //Need test input to be non-strict monotonic increasing
+//
+//  }
+}

--- a/core/src/test/scala/com/spotify/featran/transformers/SegmentIndicesSpec.scala
+++ b/core/src/test/scala/com/spotify/featran/transformers/SegmentIndicesSpec.scala
@@ -5,15 +5,15 @@ import org.scalacheck.{Arbitrary, Prop}
 
 object SegmentIndicesSpec extends TransformerProp("SegmentIndices") {
 
-  implicit lazy val randomMonotonicIncreasingArray: Arbitrary[Array[Int]] = Arbitrary {
-      val emptyArray = Array.fill(10)(0)
-      for (index <- 1 until emptyArray.length) {
+  implicit lazy val randomIncreasingArray: Arbitrary[Array[Int]] = Arbitrary {
+      val increasingArray = Array.fill(10)(0)
+      for (index <- 1 until increasingArray.length) {
         if (math.random() > 0.5) {
-          emptyArray(index) = emptyArray(index - 1) + 1
+          increasingArray(index) = increasingArray(index - 1) + 1
         } else
-          emptyArray(index) = emptyArray(index - 1)
+          increasingArray(index) = increasingArray(index - 1)
       }
-      emptyArray
+      increasingArray
   }
 
   property("default") = Prop.forAll { (xs: List[Array[Int]]) =>

--- a/examples/src/main/scala/Examples.scala
+++ b/examples/src/main/scala/Examples.scala
@@ -179,6 +179,17 @@ object Examples {
     // Extract from a single record
     recordExtractor.featureResult(recordGen.sample.get)
 
+    // This example applies the SegmentIndices transformer, which requires an increasing array of integers.
+    val segmentIndicesSpec = FeatureSpec
+      .of[Array[Int]]
+      .required(identity)(SegmentIndices("segmented"))
+
+    val f3: FeatureExtractor[List, Array[Int]] = segmentIndicesSpec.extract(List(Array(0,0,1,1,2,2)))
+
+    // Extract feature names and values as `Array[Int]` similar to other examples
+    println(f3.featureNames.head)
+    f3.featureValues[Array[Int]].foreach(println)
+
     // # Extraction with Scio
 
     // Create input `SCollection[Record]`

--- a/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
+++ b/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
@@ -104,6 +104,9 @@ package object tensorflow {
     def fromStrings(xs: Seq[String]): tf.Feature.Builder =
       fromByteStrings(xs.map(ByteString.copyFromUtf8))
 
+    def toInts(f: tf.Feature): Array[Int] = toFloats(f).map(_.toInt).toArray
+
+    def fromInts(xs: Array[Int]): tf.Feature.Builder = fromFloats(xs.map(_.toFloat))
   }
 
   /** [[FeatureBuilder]] for output as TensorFlow `Example` type. */
@@ -147,6 +150,8 @@ package object tensorflow {
 
     def readStrings(name: String): Example => Option[Seq[String]] =
       (ex: Example) => toFeature(name, ex).map(v => toStrings(v))
+
+    def readIntArray(name: String): Example => Option[Array[Int]] = (ex: Example) => toFeature(name, ex).map(v => toInts(v))
   }
 
   implicit val exampleFlatWriter: FlatWriter[Example] = new FlatWriter[tf.Example] {
@@ -194,6 +199,11 @@ package object tensorflow {
     override def writeStrings(name: String): Option[Seq[String]] => List[NamedTFFeature] =
       (v: Option[Seq[String]]) => {
         v.toList.flatMap(values => List(NamedTFFeature(name, fromStrings(values).build())))
+      }
+
+    override def writeIntArray(name: String): Option[Array[Int]] => List[NamedTFFeature] =
+      (v: Option[Array[Int]]) => {
+        v.toList.flatMap(values => List(NamedTFFeature(name, fromInts(values).build())))
       }
 
     override def writer: Seq[List[NamedTFFeature]] => Example =

--- a/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
+++ b/tensorflow/src/main/scala/com/spotify/featran/tensorflow/package.scala
@@ -104,9 +104,9 @@ package object tensorflow {
     def fromStrings(xs: Seq[String]): tf.Feature.Builder =
       fromByteStrings(xs.map(ByteString.copyFromUtf8))
 
-    def toInts(f: tf.Feature): Array[Int] = toFloats(f).map(_.toInt).toArray
+    def toInts(f: tf.Feature): Seq[Int] = toFloats(f).map(_.toInt)
 
-    def fromInts(xs: Array[Int]): tf.Feature.Builder = fromFloats(xs.map(_.toFloat))
+    def fromInts(xs: Seq[Int]): tf.Feature.Builder = fromFloats(xs.map(_.toFloat))
   }
 
   /** [[FeatureBuilder]] for output as TensorFlow `Example` type. */
@@ -151,7 +151,7 @@ package object tensorflow {
     def readStrings(name: String): Example => Option[Seq[String]] =
       (ex: Example) => toFeature(name, ex).map(v => toStrings(v))
 
-    def readIntArray(name: String): Example => Option[Array[Int]] = (ex: Example) => toFeature(name, ex).map(v => toInts(v))
+    def readIntArray(name: String): Example => Option[Array[Int]] = (ex: Example) => toFeature(name, ex).map(v => toInts(v).toArray)
   }
 
   implicit val exampleFlatWriter: FlatWriter[Example] = new FlatWriter[tf.Example] {


### PR DESCRIPTION
Had a play with solving this one: https://github.com/spotify/featran/issues/51

CL: 

- Implements an equivalent functional output to: https://github.com/tensorflow/transform/blob/master/tensorflow_transform/mappers.py#L1209  using the Transformer API on `Array[Int]` . Is efficient because it iterates over the input Array once (`O(n)`) using a fold.
-  Add support for `Int` data types with Feature Builder specifically for Segment Indices
-  Add example usage of new Transformer in Examples in plain Scala

Testing-wise, I've verified the results on a few arrays manually by running the Example as well as adding a property test which checks the result on 100 randomly generated (and valid) arrays. It does not 100% follow the pattern of other property tests in the repo which check for feature column names etc.