### PR TITLE
Upgrade SBT to 1.5.6

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -34,3 +34,6 @@ rewrite {
   redundantBraces.generalExpressions = false
   redundantBraces.maxLines = 1
 }
+
+
+runner.dialect = scala212

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.6


### PR DESCRIPTION
This commit bumps SBT to version 1.5.6.
SBT uses log4j internally for logging. A recent vulnerability has
surfaced which allows for remote code execution. SBT 1.5.6 has
been patched to include fixes for log4j internally.