### PR TITLE
Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-    - package-ecosystem: github-actions
-      directory: "/"
-      schedule:
-          interval: daily
-          time: "04:00"
-      open-pull-requests-limit: 10


### PR DESCRIPTION
All GitHub actions are now handled by sbt-typlevel plugin