### PR TITLE
Add scala3 support for the java module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -221,8 +221,11 @@ lazy val java: Project = project
     name := "java",
     moduleName := "featran-java",
     description := "Feature Transformers - java",
-    crossScalaVersions := Seq(scala213, scala212),
+    // for scala3 we need to compile scala code 1st
+    Compile / compileOrder := CompileOrder.ScalaThenJava,
+    Test / compileOrder := CompileOrder.JavaThenScala,
     libraryDependencies ++= Seq(
+      "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
       "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
       "org.scalatest" %% "scalatest" % scalatestVersion % "test"
     )

--- a/java/src/main/java/com/spotify/featran/java/SerializableFunction.java
+++ b/java/src/main/java/com/spotify/featran/java/SerializableFunction.java
@@ -18,7 +18,6 @@
 package com.spotify.featran.java;
 
 import java.io.Serializable;
+import java.util.function.Function;
 
-public interface SerializableFunction<InputT, OutputT> extends Serializable {
-  OutputT apply(InputT input);
-}
+public interface SerializableFunction<InputT, OutputT> extends Function<InputT, OutputT>, Serializable {}

--- a/java/src/main/scala/com/spotify/featran/java/JavaOps.scala
+++ b/java/src/main/scala/com/spotify/featran/java/JavaOps.scala
@@ -20,6 +20,7 @@ package com.spotify.featran.java
 import java.lang.{Double => JDouble}
 import java.util.function.BiFunction
 import java.util.{Collections, List => JList, Optional}
+import java.util.function.{Function => JFunction}
 
 import com.spotify.featran._
 import com.spotify.featran.tensorflow._
@@ -27,18 +28,18 @@ import com.spotify.featran.xgboost._
 import ml.dmlc.xgboost4j.LabeledPoint
 import org.tensorflow.proto.example.Example
 
-import scala.collection.JavaConverters._
+
+import scala.jdk.CollectionConverters._
+import scala.compat.java8.OptionConverters._
+import scala.compat.java8.FunctionConverters._
 import scala.reflect.ClassTag
 
 private object JavaOps {
-  def requiredFn[I, O](f: SerializableFunction[I, O]): I => O =
-    (input: I) => f(input)
+  def requiredFn[I, O](f: JFunction[I, O]): I => O =
+    f.asScala
 
-  def optionalFn[I, O](f: SerializableFunction[I, Optional[O]]): I => Option[O] =
-    (input: I) => {
-      val o = f(input)
-      if (o.isPresent) Some(o.get()) else None
-    }
+  def optionalFn[I, O](f: JFunction[I, Optional[O]]): I => Option[O] =
+    f.asScala.andThen(_.asScala)
 
   def crossFn(f: BiFunction[JDouble, JDouble, JDouble]): (Double, Double) => Double =
     (a, b) => f(a, b)

--- a/java/src/test/scala/com/spotify/featran/java/JavaTest.scala
+++ b/java/src/test/scala/com/spotify/featran/java/JavaTest.scala
@@ -19,13 +19,13 @@ package com.spotify.featran.java
 
 import com.spotify.featran.SparseArray
 import com.spotify.featran.xgboost.SparseLabeledPoint
-import org.tensorflow.proto.example.Example
-
-import scala.collection.JavaConverters._
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.tensorflow.proto.example.Example
+
+import scala.jdk.CollectionConverters._
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 
 class JavaTest extends AnyFlatSpec with Matchers {
   import com.spotify.featran.Fixtures._


### PR DESCRIPTION
`java` module wasn't building with scala 3 due to type conflict as explained in https://github.com/lampepfl/dotty/discussions/16797#discussioncomment-4845603.
Proposed solution to change compiling order worked